### PR TITLE
refactor and rename: minimum action methods with type based optimizers 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ examples/Manifest.toml
 benchmarks_output.json
 benchmarks/Manifest.toml
 Manifest.toml
+.claude/*

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sys = CoupledSDEs(fitzhugh_nagumo, initial_state, params; noise_strength)
 traj = trajectory(sys, 10.0)
 
 # Compute minimum action path using gMAM algorithm
-instanton = geometric_min_action_method(sys, initial_state, current_state(sys))
+instanton = minimize_geometric_action(sys, initial_state, current_state(sys))
 
 # Turn into a non-autonomous dynamical system
 # where the parameter β changes in time

--- a/benchmarks/implementation_benchmarks/KPO_sgMAM.jl
+++ b/benchmarks/implementation_benchmarks/KPO_sgMAM.jl
@@ -59,12 +59,12 @@ yy = @. (xb[2] - xa[2]) * s + xa[2] + 4 * s * (1 - s) * xsaddle[2] + 0.01 * sin(
 x_initial = Matrix([xx yy]')
 
 MLP = simple_geometric_min_action_method(
-    sys, x_initial; iterations=100_000, ϵ=10e2, show_progress=true
+    sys, x_initial; maxiters=100_000, stepsize=10e2, show_progress=true
 )
 x_min = MLP.path
 S_min = MLP.action
 
-string = string_method(sys, x_initial; iterations=100_000, ϵ=0.5, show_progress=true)
+string = string_method(sys, x_initial; maxiters=100_000, stepsize=0.5, show_progress=true)
 
 @show S_min;
 plot(x_initial[1, :], x_initial[2, :]; label="init", lw=3, c=:black)
@@ -73,10 +73,10 @@ string_path = permutedims(Matrix(string))
 plot!(string_path[1, :], string_path[2, :]; label="string", lw=3, c=:blue)
 
 @btime $simple_geometric_min_action_method(
-    $sys, $x_initial, iterations=100, ϵ=10e2, show_progress=false
+    $sys, $x_initial, maxiters=100, stepsize=10e2, show_progress=false
 ) # 25.803 ms (29024 allocations: 105.69 MiB)
 @profview simple_geometric_min_action_method(
-    sys, x_initial, iterations=100, ϵ=10e2, show_progress=false
+    sys, x_initial, maxiters=100, stepsize=10e2, show_progress=false
 )
 
 # The bottleneck is atm at the LinearSolve call to update the x in the new iteration. So the more improve, one needs to write it own LU factorization.

--- a/benchmarks/implementation_benchmarks/KPO_sgMAM.jl
+++ b/benchmarks/implementation_benchmarks/KPO_sgMAM.jl
@@ -59,7 +59,7 @@ yy = @. (xb[2] - xa[2]) * s + xa[2] + 4 * s * (1 - s) * xsaddle[2] + 0.01 * sin(
 x_initial = Matrix([xx yy]')
 
 opt = GeometricGradient(; stepsize=10e2)
-MLP = simple_geometric_min_action_method(
+MLP = minimize_simple_geometric_action(
     sys, x_initial, opt; maxiters=100_000, show_progress=true
 )
 x_min = MLP.path
@@ -73,10 +73,10 @@ plot!(x_min[1, :], x_min[2, :]; label="MLP", lw=3, c=:red)
 string_path = permutedims(Matrix(string))
 plot!(string_path[1, :], string_path[2, :]; label="string", lw=3, c=:blue)
 
-@btime $simple_geometric_min_action_method(
+@btime $minimize_simple_geometric_action(
     $sys, $x_initial, $opt; maxiters=100, show_progress=false
 ) # 25.803 ms (29024 allocations: 105.69 MiB)
-@profview simple_geometric_min_action_method(
+@profview minimize_simple_geometric_action(
     sys, x_initial, opt; maxiters=100, show_progress=false
 )
 

--- a/benchmarks/implementation_benchmarks/KPO_sgMAM.jl
+++ b/benchmarks/implementation_benchmarks/KPO_sgMAM.jl
@@ -58,8 +58,9 @@ xx = @. (xb[1] - xa[1]) * s + xa[1] + 4 * s * (1 - s) * xsaddle[1]
 yy = @. (xb[2] - xa[2]) * s + xa[2] + 4 * s * (1 - s) * xsaddle[2] + 0.01 * sin(2π * s)
 x_initial = Matrix([xx yy]')
 
+opt = GeometricGradient(; stepsize=10e2)
 MLP = simple_geometric_min_action_method(
-    sys, x_initial; maxiters=100_000, stepsize=10e2, show_progress=true
+    sys, x_initial, opt; maxiters=100_000, show_progress=true
 )
 x_min = MLP.path
 S_min = MLP.action
@@ -73,10 +74,10 @@ string_path = permutedims(Matrix(string))
 plot!(string_path[1, :], string_path[2, :]; label="string", lw=3, c=:blue)
 
 @btime $simple_geometric_min_action_method(
-    $sys, $x_initial, maxiters=100, stepsize=10e2, show_progress=false
+    $sys, $x_initial, $opt; maxiters=100, show_progress=false
 ) # 25.803 ms (29024 allocations: 105.69 MiB)
 @profview simple_geometric_min_action_method(
-    sys, x_initial, maxiters=100, stepsize=10e2, show_progress=false
+    sys, x_initial, opt; maxiters=100, show_progress=false
 )
 
 # The bottleneck is atm at the LinearSolve call to update the x in the new iteration. So the more improve, one needs to write it own LU factorization.

--- a/benchmarks/implementation_benchmarks/heymann_vandeneijnden.jl
+++ b/benchmarks/implementation_benchmarks/heymann_vandeneijnden.jl
@@ -16,12 +16,11 @@ xx = range(-1.0, 1.0; length=N)
 yy = 0.3 .* (-xx .^ 2 .+ 1)
 init = Matrix([xx yy]')
 
-@btime CriticalTransitions.geometric_gradient_step($sys, $init, $N; tau=0.1)
+@btime CriticalTransitions.geometric_gradient_step($sys, $init, $N; stepsize=0.1)
 @btime geometric_min_action_method(
     $sys,
-    $init;
+    $init, GeometricGradient();
     maxiters=10,
     show_progress=false,
-    optimizer=GeometricGradient(),
     stepsize=0.1,
 )

--- a/benchmarks/implementation_benchmarks/heymann_vandeneijnden.jl
+++ b/benchmarks/implementation_benchmarks/heymann_vandeneijnden.jl
@@ -18,9 +18,5 @@ init = Matrix([xx yy]')
 
 @btime CriticalTransitions.geometric_gradient_step($sys, $init, $N; stepsize=0.1)
 @btime geometric_min_action_method(
-    $sys,
-    $init, GeometricGradient();
-    maxiters=10,
-    show_progress=false,
-    stepsize=0.1,
+    $sys, $init, GeometricGradient(); maxiters=10, show_progress=false, stepsize=0.1
 )

--- a/benchmarks/implementation_benchmarks/heymann_vandeneijnden.jl
+++ b/benchmarks/implementation_benchmarks/heymann_vandeneijnden.jl
@@ -17,6 +17,6 @@ yy = 0.3 .* (-xx .^ 2 .+ 1)
 init = Matrix([xx yy]')
 
 @btime CriticalTransitions.geometric_gradient_step($sys, $init, $N; stepsize=0.1)
-@btime geometric_min_action_method(
+@btime minimize_geometric_action(
     $sys, $init, GeometricGradient(; stepsize=0.1); maxiters=10, show_progress=false
 )

--- a/benchmarks/implementation_benchmarks/heymann_vandeneijnden.jl
+++ b/benchmarks/implementation_benchmarks/heymann_vandeneijnden.jl
@@ -18,5 +18,5 @@ init = Matrix([xx yy]')
 
 @btime CriticalTransitions.geometric_gradient_step($sys, $init, $N; stepsize=0.1)
 @btime geometric_min_action_method(
-    $sys, $init, GeometricGradient(); maxiters=10, show_progress=false, stepsize=0.1
+    $sys, $init, GeometricGradient(; stepsize=0.1); maxiters=10, show_progress=false
 )

--- a/benchmarks/kpo.jl
+++ b/benchmarks/kpo.jl
@@ -53,7 +53,7 @@ function benchmark_KPO!(SUITE)
     x_initial = Matrix([xx yy]')
 
     opt = GeometricGradient(; stepsize=10e2)
-    SUITE["Large deviation"]["Simple geometric minimal action"]["KPO"] = @benchmarkable simple_geometric_min_action_method(
+    SUITE["Large deviation"]["Simple geometric minimal action"]["KPO"] = @benchmarkable minimize_simple_geometric_action(
         $sys, $x_initial, $opt; maxiters=10_000, show_progress=false
     ) seconds = 10
 
@@ -72,7 +72,7 @@ function benchmark_KPO!(SUITE)
     # end
     # ds_sa = CoupledSDEs(KPO_SA, zeros(2), ())
 
-    # SUITE["Large deviation"]["Geometric minimal action"]["KPO (Optimisers.Adam; AutoFiniteDiff)"] = @benchmarkable geometric_min_action_method(
+    # SUITE["Large deviation"]["Geometric minimal action"]["KPO (Optimisers.Adam; AutoFiniteDiff)"] = @benchmarkable minimize_geometric_action(
     #     $ds_sa, $x_initial; maxiters=100, show_progress=false
     # ) seconds = 20
     return nothing

--- a/benchmarks/kpo.jl
+++ b/benchmarks/kpo.jl
@@ -52,8 +52,9 @@ function benchmark_KPO!(SUITE)
     yy = @. (xb[2] - xa[2]) * s + xa[2] + 4 * s * (1 - s) * xsaddle[2] + 0.01 * sin(2π * s)
     x_initial = Matrix([xx yy]')
 
+    opt = GeometricGradient(; stepsize=10e2)
     SUITE["Large deviation"]["Simple geometric minimal action"]["KPO"] = @benchmarkable simple_geometric_min_action_method(
-        $sys, $x_initial; maxiters=10_000, stepsize=10e2, show_progress=false
+        $sys, $x_initial, $opt; maxiters=10_000, show_progress=false
     ) seconds = 10
 
     SUITE["Large deviation"]["String method"]["Kerr parametric resonator"] = @benchmarkable string_method(

--- a/benchmarks/maierstein.jl
+++ b/benchmarks/maierstein.jl
@@ -17,11 +17,12 @@ function benchmark_maierstein!(SUITE)
     x_i = init[:, 1]
     x_f = init[:, end]
 
+    optimizer=Optimisers.Adam()
     SUITE["Large deviation"]["Geometric minimal action"]["Maier-Stein (Optimisers.Adam; AutoFiniteDiff)"] = @benchmarkable geometric_min_action_method(
-        $sys, $init; maxiters=1000, show_progress=false, optimizer=Optimisers.Adam()
+        $sys, $init, $optimizer; maxiters=1000, show_progress=false
     ) seconds = 10
     SUITE["Large deviation"]["Geometric minimal action"]["Maier-Stein (HeymannVandenEijnden)"] = @benchmarkable geometric_min_action_method(
-        $sys, $init; maxiters=1000, show_progress=false, optimizer=GeometricGradient()
+        $sys, $init, GeometricGradient(); maxiters=1000, show_progress=false
     ) seconds = 10
     return nothing
 end

--- a/benchmarks/maierstein.jl
+++ b/benchmarks/maierstein.jl
@@ -18,10 +18,10 @@ function benchmark_maierstein!(SUITE)
     x_f = init[:, end]
 
     optimizer=Optimisers.Adam()
-    SUITE["Large deviation"]["Geometric minimal action"]["Maier-Stein (Optimisers.Adam; AutoFiniteDiff)"] = @benchmarkable geometric_min_action_method(
+    SUITE["Large deviation"]["Geometric minimal action"]["Maier-Stein (Optimisers.Adam; AutoFiniteDiff)"] = @benchmarkable minimize_geometric_action(
         $sys, $init, $optimizer; maxiters=1000, show_progress=false
     ) seconds = 10
-    SUITE["Large deviation"]["Geometric minimal action"]["Maier-Stein (HeymannVandenEijnden)"] = @benchmarkable geometric_min_action_method(
+    SUITE["Large deviation"]["Geometric minimal action"]["Maier-Stein (HeymannVandenEijnden)"] = @benchmarkable minimize_geometric_action(
         $sys, $init, GeometricGradient(); maxiters=1000, show_progress=false
     ) seconds = 10
     return nothing

--- a/docs/src/examples/gMAM_Maierstein.md
+++ b/docs/src/examples/gMAM_Maierstein.md
@@ -285,7 +285,7 @@ init = Matrix([xx yy]')
 
 ````@example gMAM_Maierstein
 optimizer = GeometricGradient()
-gm = geometric_min_action_method(sys, init; maxiters=500, show_progress=false, optimizer)
+gm = geometric_min_action_method(sys, init, optimizer; maxiters=500, show_progress=false)
 MLP = gm.path
 ````
 
@@ -330,4 +330,3 @@ fig
 ---
 
 *This page was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*
-

--- a/docs/src/examples/gMAM_Maierstein.md
+++ b/docs/src/examples/gMAM_Maierstein.md
@@ -281,11 +281,11 @@ yy = 0.3 .* (-xx .^ 2 .+ 1)
 init = Matrix([xx yy]')
 ````
 
-`geometric_min_action_method` computes the minimizer of the Freidlin-Wentzell action using the geometric minimum action method (gMAM), to find the minimum action path (instanton) between an initial state x_i and final state x_f. The Minimum Action Method (MAM) is a more traditional approach, while the Geometric Minimum Action Method (gMAM) is a blend of the original MAM and the [string method](https://doi.org/10.1103/PhysRevB.66.052301).
+`minimize_geometric_action` computes the minimizer of the Freidlin-Wentzell action using the geometric minimum action method (gMAM), to find the minimum action path (instanton) between an initial state x_i and final state x_f. The Minimum Action Method (MAM) is a more traditional approach, while the Geometric Minimum Action Method (gMAM) is a blend of the original MAM and the [string method](https://doi.org/10.1103/PhysRevB.66.052301).
 
 ````@example gMAM_Maierstein
 optimizer = GeometricGradient()
-gm = geometric_min_action_method(sys, init, optimizer; maxiters=500, show_progress=false)
+gm = minimize_geometric_action(sys, init, optimizer; maxiters=500, show_progress=false)
 MLP = gm.path
 ````
 

--- a/docs/src/examples/sgMAM_KPO.md
+++ b/docs/src/examples/sgMAM_KPO.md
@@ -88,8 +88,9 @@ x_initial = Matrix([xx yy]')
 The optimisation is the performed by the `simple_geometric_min_action_method` function:
 
 ````@example sgMAM_KPO
+optimizer = GeometricGradient(; stepsize=1e3)
 MLP = simple_geometric_min_action_method(
-    sys, x_initial; maxiters=1_000, stepsize=10e2, show_progress=false
+    sys, x_initial, optimizer; maxiters=1_000, show_progress=false
 )
 x_min = MLP.path;
 nothing #hide
@@ -119,4 +120,3 @@ fig
 ---
 
 *This page was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*
-

--- a/docs/src/examples/sgMAM_KPO.md
+++ b/docs/src/examples/sgMAM_KPO.md
@@ -85,11 +85,11 @@ yy = @. (xb[2] - xa[2]) * s + xa[2] + 4 * s * (1 - s) * xsaddle[2] + 0.01 * sin(
 x_initial = Matrix([xx yy]')
 ````
 
-The optimisation is the performed by the `simple_geometric_min_action_method` function:
+The optimisation is the performed by the `minimize_simple_geometric_action` function:
 
 ````@example sgMAM_KPO
 optimizer = GeometricGradient(; stepsize=1e3)
-MLP = simple_geometric_min_action_method(
+MLP = minimize_simple_geometric_action(
     sys, x_initial, optimizer; maxiters=1_000, show_progress=false
 )
 x_min = MLP.path;

--- a/docs/src/man/largedeviations.md
+++ b/docs/src/man/largedeviations.md
@@ -83,8 +83,9 @@ sys_fast = ExtendedPhaseSpace{false,2}(H_x, H_p)  # hardcoded analytic H_x/H_p
 ds = CoupledSDEs(KPO, zeros(2), ())
 sys_generic = ExtendedPhaseSpace(ds)              # uses jacobian(ds)
 
-@btime simple_geometric_min_action_method($sys_fast,    $x_initial; maxiters=100, stepsize=0.5, show_progress=false)
-@btime simple_geometric_min_action_method($sys_generic, $x_initial; maxiters=100, stepsize=0.5, show_progress=false)
+opt = GeometricGradient(; stepsize=0.5)
+@btime simple_geometric_min_action_method($sys_fast,    $x_initial, $opt; maxiters=100, show_progress=false)
+@btime simple_geometric_min_action_method($sys_generic, $x_initial, $opt; maxiters=100, show_progress=false)
 ```
 
 Aside: the same “vectorized + allocation-free inner loop” principle also tends to make [`string_method`](@ref) faster when used with `ExtendedPhaseSpace`.

--- a/docs/src/man/largedeviations.md
+++ b/docs/src/man/largedeviations.md
@@ -42,14 +42,14 @@ The literature contains a number of extensions of MAM-type methods that may be r
 Minimization of the specified action functional using the optimization algorithm of `Optimization.jl`. See also [e_minimum_2004](@citet).
 
 ```@docs
-min_action_method
+minimize_action
 ```
 
 ### Geometric minimum action method (gMAM)
 Minimization of the geometric action following [heymann_pathways_2008, heymann_geometric_2008](@citet). gMAM reformulates MAM to avoid double optimization of both the action and the transition time. It achieves this by using a [geometric action](@ref "Geometric Freidlin-Wentzell action") functional that is independent of the time parametrization of the path. This reparameterization invariance makes the method more robust and computationally efficient, particularly for multiscale systems.
 
 ```@docs
-geometric_min_action_method
+minimize_geometric_action
 ```
 
 ### Simple geometric minimum action method (sgMAM)
@@ -58,7 +58,7 @@ The simple gMAM reduces the complexity of the original gMAM by requiring only fi
 
 The implementation below performs a constrained gradient descent assuming an autonomous system with additive Gaussian noise.
 ```@docs
-simple_geometric_min_action_method
+minimize_simple_geometric_action
 ExtendedPhaseSpace
 ```
 
@@ -84,8 +84,8 @@ ds = CoupledSDEs(KPO, zeros(2), ())
 sys_generic = ExtendedPhaseSpace(ds)              # uses jacobian(ds)
 
 opt = GeometricGradient(; stepsize=0.5)
-@btime simple_geometric_min_action_method($sys_fast,    $x_initial, $opt; maxiters=100, show_progress=false)
-@btime simple_geometric_min_action_method($sys_generic, $x_initial, $opt; maxiters=100, show_progress=false)
+@btime minimize_simple_geometric_action($sys_fast,    $x_initial, $opt; maxiters=100, show_progress=false)
+@btime minimize_simple_geometric_action($sys_generic, $x_initial, $opt; maxiters=100, show_progress=false)
 ```
 
 Aside: the same “vectorized + allocation-free inner loop” principle also tends to make [`string_method`](@ref) faster when used with `ExtendedPhaseSpace`.

--- a/examples/gMAM_Maierstein.jl
+++ b/examples/gMAM_Maierstein.jl
@@ -263,7 +263,7 @@ init = Matrix([xx yy]')
 
 # `geometric_min_action_method` computes the minimizer of the Freidlin-Wentzell action using the geometric minimum action method (gMAM), to find the minimum action path (instanton) between an initial state x_i and final state x_f. The Minimum Action Method (MAM) is a more traditional approach, while the Geometric Minimum Action Method (gMAM) is a blend of the original MAM and the [string method](https://doi.org/10.1103/PhysRevB.66.052301).
 optimizer = GeometricGradient()
-gm = geometric_min_action_method(sys, init; maxiters=500, show_progress=false, optimizer)
+gm = geometric_min_action_method(sys, init, optimizer; maxiters=500, show_progress=false)
 MLP = gm.path
 
 #

--- a/examples/gMAM_Maierstein.jl
+++ b/examples/gMAM_Maierstein.jl
@@ -261,9 +261,9 @@ xx = range(-1.0, 1.0; length=100)
 yy = 0.3 .* (-xx .^ 2 .+ 1)
 init = Matrix([xx yy]')
 
-# `geometric_min_action_method` computes the minimizer of the Freidlin-Wentzell action using the geometric minimum action method (gMAM), to find the minimum action path (instanton) between an initial state x_i and final state x_f. The Minimum Action Method (MAM) is a more traditional approach, while the Geometric Minimum Action Method (gMAM) is a blend of the original MAM and the [string method](https://doi.org/10.1103/PhysRevB.66.052301).
+# `minimize_geometric_action` computes the minimizer of the Freidlin-Wentzell action using the geometric minimum action method (gMAM), to find the minimum action path (instanton) between an initial state x_i and final state x_f. The Minimum Action Method (MAM) is a more traditional approach, while the Geometric Minimum Action Method (gMAM) is a blend of the original MAM and the [string method](https://doi.org/10.1103/PhysRevB.66.052301).
 optimizer = GeometricGradient()
-gm = geometric_min_action_method(sys, init, optimizer; maxiters=500, show_progress=false)
+gm = minimize_geometric_action(sys, init, optimizer; maxiters=500, show_progress=false)
 MLP = gm.path
 
 #

--- a/examples/old/gmam_Maierstein.jl
+++ b/examples/old/gmam_Maierstein.jl
@@ -28,7 +28,7 @@ xx = range(-1.0, 1.0; length=100)
 yy = 0.3 .* (-xx .^ 2 .+ 1)
 init = Matrix([xx yy]')
 
-gm = geometric_min_action_method(sys, init; maxiters=1000, Stol=1e-6, iter_per_batch=1)
+gm = minimize_geometric_action(sys, init; maxiters=1000, Stol=1e-6, iter_per_batch=1)
 
 begin
     u_min = -1.1

--- a/examples/sgMAM_KPO.jl
+++ b/examples/sgMAM_KPO.jl
@@ -72,8 +72,9 @@ x_initial = Matrix([xx yy]')
 
 # The optimisation is the performed by the `simple_geometric_min_action_method` function:
 
+optimizer = GeometricGradient(; stepsize=1e3)
 MLP = simple_geometric_min_action_method(
-    sys, x_initial; maxiters=1_000, stepsize=10e2, show_progress=false
+    sys, x_initial, optimizer; maxiters=1_000, show_progress=false
 )
 x_min = MLP.path;
 

--- a/examples/sgMAM_KPO.jl
+++ b/examples/sgMAM_KPO.jl
@@ -70,10 +70,10 @@ xx = @. (xb[1] - xa[1]) * s + xa[1] + 4 * s * (1 - s) * xsaddle[1]
 yy = @. (xb[2] - xa[2]) * s + xa[2] + 4 * s * (1 - s) * xsaddle[2] + 0.01 * sin(2π * s)
 x_initial = Matrix([xx yy]')
 
-# The optimisation is the performed by the `simple_geometric_min_action_method` function:
+# The optimisation is the performed by the `minimize_simple_geometric_action` function:
 
 optimizer = GeometricGradient(; stepsize=1e3)
-MLP = simple_geometric_min_action_method(
+MLP = minimize_simple_geometric_action(
     sys, x_initial, optimizer; maxiters=1_000, show_progress=false
 )
 x_min = MLP.path;

--- a/src/CriticalTransitions.jl
+++ b/src/CriticalTransitions.jl
@@ -58,6 +58,7 @@ include("trajectories/transition.jl")
 
 include("largedeviations/utils.jl")
 include("largedeviations/action.jl")
+include("largedeviations/methods.jl")
 include("largedeviations/MinimumActionPath.jl")
 include("largedeviations/min_action_method.jl")
 include("largedeviations/geometric_min_action_method.jl")

--- a/src/CriticalTransitions.jl
+++ b/src/CriticalTransitions.jl
@@ -60,8 +60,8 @@ include("largedeviations/utils.jl")
 include("largedeviations/action.jl")
 include("largedeviations/methods.jl")
 include("largedeviations/MinimumActionPath.jl")
-include("largedeviations/min_action_method.jl")
-include("largedeviations/geometric_min_action_method.jl")
+include("largedeviations/minimize_action.jl")
+include("largedeviations/minimize_geometric_action.jl")
 
 include("largedeviations/sgMAM.jl")
 include("largedeviations/string_method.jl")
@@ -85,9 +85,9 @@ export CoupledSDEs, CoupledODEs, noise_process, covariance_matrix, diffusion_mat
 export drift, div_drift, solver
 export StateSpaceSet
 
-export simple_geometric_min_action_method, ExtendedPhaseSpace
+export minimize_simple_geometric_action, ExtendedPhaseSpace
 export fw_action, om_action, action, geometric_action
-export min_action_method, action_minimizer, geometric_min_action_method, string_method
+export minimize_action, action_minimizer, minimize_geometric_action, string_method
 export MinimumActionPath
 export GeometricGradient
 

--- a/src/largedeviations/geometric_min_action_method.jl
+++ b/src/largedeviations/geometric_min_action_method.jl
@@ -16,8 +16,7 @@ To set an initial path different from a straight line, see the multiple dispatch
   - `maxiters::Int=100`: maximum number of optimization iterations before the algorithm stops
   - `abstol::Real=NaN`: absolute tolerance of action change to determine convergence
   - `reltol::Real=NaN`: relative tolerance of action change to determine convergence
-  - `stepsize=0.01`: step size parameter for projected gradient descent. Default: `0.01`
-  - `ad_type=Optimization.AutoFiniteDiff()`: type of automatic differentiation for Optimization.jl solvers
+  - `ad_type=Optimization.AutoFiniteDiff()`: type of automatic differentiation (only used with Optimization.jl solvers)
   - `verbose=false`: if true, print additional output
   - `show_progress=true`: if true, display a progress bar
 
@@ -33,10 +32,15 @@ The `optimizer` argument accepts:
 """
 
 function geometric_min_action_method(
-    sys::ContinuousTimeDynamicalSystem, x_i, x_f; points::Int=100, kwargs...
+    sys::ContinuousTimeDynamicalSystem,
+    x_i,
+    x_f,
+    optimizer=GeometricGradient();
+    points::Int=100,
+    kwargs...,
 )
     path = reduce(hcat, range(x_i, x_f; length=points))
-    return geometric_min_action_method(sys, path; kwargs...)
+    return geometric_min_action_method(sys, path, optimizer; kwargs...)
 end
 
 """
@@ -52,6 +56,19 @@ For more information see the main method,
 [`geometric_min_action_method(sys::CoupledSDEs, x_i, x_f, arclength::Real; kwargs...)`](@ref).
 """
 
+function _gmam_setup(sys, init, maxiters, show_progress)
+    if sys isa CoupledSDEs
+        proper_MAM_system(sys)
+    end
+    path = deepcopy(init)
+    N = length(init[1, :])
+    alpha = zeros(N)
+    arc = range(0, 1.0; length=N)
+    S(x) = geometric_action(sys, fix_ends(x, init[:, 1], init[:, end]), 1.0)
+    prog = Progress(maxiters; enabled=show_progress)
+    return path, N, alpha, arc, S, prog
+end
+
 function geometric_min_action_method(
     sys::ContinuousTimeDynamicalSystem, init::Matrix; kwargs...
 )
@@ -64,27 +81,16 @@ function geometric_min_action_method(
     maxiters::Int=100,
     abstol::Real=NaN,
     reltol::Real=NaN,
-    stepsize=0.01,
     verbose=false,
     show_progress=true,
 )
-    if sys isa CoupledSDEs
-        proper_MAM_system(sys)
-    end
+    path, N, alpha, arc, S, prog = _gmam_setup(sys, init, maxiters, show_progress)
 
-    path = deepcopy(init)
-    N = length(init[1, :])
-    alpha = zeros(N)
-    arc = range(0, 1.0; length=N)
-
-    S(x) = geometric_action(sys, fix_ends(x, init[:, 1], init[:, end]), 1.0)
-
-    prog = Progress(maxiters; enabled=show_progress)
     ws = geometric_gradient_workspace(sys, path)
     check_convergence = isfinite(abstol) || isfinite(reltol)
     prev_action = check_convergence ? S(path) : NaN
     for i in 1:maxiters
-        geometric_gradient_step!(ws, sys, path; stepsize=stepsize)
+        geometric_gradient_step!(ws, sys, path; stepsize=optimizer.stepsize)
         path .= ws.update
         interpolate_path!(path, alpha, arc)
         next!(prog)
@@ -114,22 +120,10 @@ function geometric_min_action_method(
     abstol::Real=NaN,
     reltol::Real=NaN,
     ad_type=Optimization.AutoFiniteDiff(),
-    stepsize=0.01,
-    verbose=false,
     show_progress=true,
 )
-    if sys isa CoupledSDEs
-        proper_MAM_system(sys)
-    end
+    path, N, alpha, arc, S, prog = _gmam_setup(sys, init, maxiters, show_progress)
 
-    path = deepcopy(init)
-    N = length(init[1, :])
-    alpha = zeros(N)
-    arc = range(0, 1.0; length=N)
-
-    S(x) = geometric_action(sys, fix_ends(x, init[:, 1], init[:, end]), 1.0)
-
-    prog = Progress(maxiters; enabled=show_progress)
     optf = SciMLBase.OptimizationFunction((x, _) -> S(x), ad_type)
     prob = SciMLBase.OptimizationProblem(optf, init, ())
 

--- a/src/largedeviations/geometric_min_action_method.jl
+++ b/src/largedeviations/geometric_min_action_method.jl
@@ -1,10 +1,13 @@
 """
-$(TYPEDSIGNATURES)
+    geometric_min_action_method(sys::CoupledSDEs, x_i, x_f, optimizer=GeometricGradient(); kwargs...)
 
 Computes the minimizer of the geometric Freidlin-Wentzell action based on the geometric
 minimum action method (gMAM), using optimizers of Optimization.jl or the original formulation
-by Heymann and Vanden-Eijnden [heymann_pathways_2008](@citet), which performs a projected-gradient
-descent. Only the Freidlin-Wentzell action has a geometric formulation.
+by Heymann and Vanden-Eijnden [heymann_pathways_2008](@citet), which performs a projected gradient
+descent.
+
+The minimizer is computed for the system `sys` over all paths leading from the initial state
+`x_i` to the final state `x_f`.
 
 To set an initial path different from a straight line, see the multiple dispatch method
 
@@ -12,7 +15,7 @@ To set an initial path different from a straight line, see the multiple dispatch
 
 ## Keyword arguments
 
-  - `points::Int=100`: number of discretization points along the path
+  - `npoints::Int=100`: number of discretization points along the path
   - `maxiters::Int=100`: maximum number of optimization iterations before the algorithm stops
   - `abstol::Real=NaN`: absolute tolerance of action change to determine convergence
   - `reltol::Real=NaN`: relative tolerance of action change to determine convergence
@@ -20,26 +23,28 @@ To set an initial path different from a straight line, see the multiple dispatch
   - `verbose=false`: if true, print additional output
   - `show_progress=true`: if true, display a progress bar
 
+## Minimization algorithms
+
 The optional positional argument `optimizer` selects the minimization algorithm. It defaults to
 `GeometricGradient()`. Pass any Optimization.jl optimizer to use Optimization.jl; `ad_type` is only
 used in that case.
 
-## Minimization algorithms
-
 The `optimizer` argument accepts:
   - `GeometricGradient()`: runs a projected-gradient gradient descent [heymann_pathways_2008](@citet)
   - Any solver from [`Optimization.jl`](https://docs.sciml.ai/Optimization/) (e.g., `OptimizationOptimisers.Adam()`)
-"""
 
+## Notes
+Only the Freidlin-Wentzell action has a geometric formulation.
+"""
 function geometric_min_action_method(
     sys::ContinuousTimeDynamicalSystem,
     x_i,
     x_f,
     optimizer=GeometricGradient();
-    points::Int=100,
+    npoints::Int=100,
     kwargs...,
 )
-    path = reduce(hcat, range(x_i, x_f; length=points))
+    path = reduce(hcat, range(x_i, x_f; length=npoints))
     return geometric_min_action_method(sys, path, optimizer; kwargs...)
 end
 

--- a/src/largedeviations/geometric_min_action_method.jl
+++ b/src/largedeviations/geometric_min_action_method.jl
@@ -43,19 +43,6 @@ function geometric_min_action_method(
     return geometric_min_action_method(sys, path, optimizer; kwargs...)
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Runs the geometric Minimum Action Method (gMAM) to find the minimum action path (instanton) from an
-initial condition `init`, given a system `sys` and total arc length `arclength`.
-
-The initial path `init` must be a matrix of size `(D, N)`, where `D` is the dimension of the
-system and `N` is the number of path points.
-
-For more information see the main method,
-[`geometric_min_action_method(sys::CoupledSDEs, x_i, x_f, arclength::Real; kwargs...)`](@ref).
-"""
-
 function _gmam_setup(sys, init, maxiters, show_progress)
     if sys isa CoupledSDEs
         proper_MAM_system(sys)
@@ -74,6 +61,19 @@ function geometric_min_action_method(
 )
     return geometric_min_action_method(sys, init, GeometricGradient(); kwargs...)
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Runs the geometric Minimum Action Method (gMAM) to find the minimum action path (instanton) from an
+initial condition `init`, given a system `sys` and total arc length `arclength`.
+
+The initial path `init` must be a matrix of size `(D, N)`, where `D` is the dimension of the
+system and `N` is the number of path points.
+
+For more information see the main method,
+[`geometric_min_action_method(sys::CoupledSDEs, x_i, x_f, arclength::Real; kwargs...)`](@ref).
+"""
 function geometric_min_action_method(
     sys::ContinuousTimeDynamicalSystem,
     init::Matrix,

--- a/src/largedeviations/methods.jl
+++ b/src/largedeviations/methods.jl
@@ -1,0 +1,2 @@
+abstract type GMAMOptimizer end
+struct GeometricGradient <: GMAMOptimizer end

--- a/src/largedeviations/methods.jl
+++ b/src/largedeviations/methods.jl
@@ -1,12 +1,23 @@
 abstract type GMAMOptimizer end
 
 """
-    GeometricGradient(; stepsize=0.01)
+$(TYPEDEF)
 
 Projected-gradient descent optimizer for the geometric minimum action method
 [heymann_pathways_2008](@citet).
+
+# Fields
+$(TYPEDFIELDS)
+
+# Keyword constructors
+$(METHODLIST)
 """
-struct GeometricGradient{T} <: GMAMOptimizer
+struct GeometricGradient{T<:Real} <: GMAMOptimizer
+    """Step size for the projected gradient update."""
     stepsize::T
 end
-GeometricGradient(; stepsize=0.01) = GeometricGradient(stepsize)
+
+function GeometricGradient(; stepsize::Real=0.01)
+    T = typeof(float(stepsize))
+    return GeometricGradient{T}(T(stepsize))
+end

--- a/src/largedeviations/methods.jl
+++ b/src/largedeviations/methods.jl
@@ -1,2 +1,12 @@
 abstract type GMAMOptimizer end
-struct GeometricGradient <: GMAMOptimizer end
+
+"""
+    GeometricGradient(; stepsize=0.01)
+
+Projected-gradient descent optimizer for the geometric minimum action method
+[heymann_pathways_2008](@citet).
+"""
+struct GeometricGradient{T} <: GMAMOptimizer
+    stepsize::T
+end
+GeometricGradient(; stepsize=0.01) = GeometricGradient(stepsize)

--- a/src/largedeviations/min_action_method.jl
+++ b/src/largedeviations/min_action_method.jl
@@ -36,7 +36,13 @@ The optional positional argument `optimizer` selects the Optimization.jl solver.
   - `show_progress = false`: whether to print a progress bar
 """
 function min_action_method(
-    sys::ContinuousTimeDynamicalSystem, x_i, x_f, T::Real, optimizer=Optimisers.Adam(); points::Int=100, kwargs...
+    sys::ContinuousTimeDynamicalSystem,
+    x_i,
+    x_f,
+    T::Real,
+    optimizer=Optimisers.Adam();
+    points::Int=100,
+    kwargs...,
 )
     init = reduce(hcat, range(x_i, x_f; length=points))
     return min_action_method(sys, init, T, optimizer; kwargs...)

--- a/src/largedeviations/min_action_method.jl
+++ b/src/largedeviations/min_action_method.jl
@@ -1,5 +1,5 @@
 """
-    min_action_method(sys::ContinuousTimeDynamicalSystem, x_i, x_f, T::Real; kwargs...)
+    min_action_method(sys::ContinuousTimeDynamicalSystem, x_i, x_f, T::Real, optimizer=Optimisers.Adam(); kwargs...)
 
 Minimizes an action functional to obtain a minimum action path (instanton) between an
 initial state `x_i` and final state `x_f` in phase space.
@@ -14,10 +14,12 @@ time via `N` equidistant points and total time `T`. Thus, the time step between
 discretized path points is ``\\Delta t = T/N``.
 To set an initial path different from a straight line, see the multiple dispatch method
 
-> `min_action_method(sys::ContinuousTimeDynamicalSystem, init::Matrix, T::Real; kwargs...)`.
+> `min_action_method(sys::ContinuousTimeDynamicalSystem, init::Matrix, T::Real, optimizer=Optimisers.Adam(); kwargs...)`.
 
 Returns a [`MinimumActionPath`](@ref) object containing the optimized path and the action
 value.
+
+The optional positional argument `optimizer` selects the Optimization.jl solver. It defaults to `Optimisers.Adam()`.
 
 ## Keyword arguments
 
@@ -25,7 +27,6 @@ value.
     Defaults to [`fw_action`](@ref), alternative: "OM" for [`om_action`](@ref)
   - `points = 100`: number of path points to use for the discretization of the path
   - `noise_strength = nothing`: noise strength for the action functional. Specify only if `functional = "OM"`
-  - `optimizer = Optimisers.Adam()`: minimization algorithm from [`Optimization.jl`](https://docs.sciml.ai/Optimization/stable/optimization_packages/optimisers/)
   - `ad_type = Optimization.AutoFiniteDiff()`: type of automatic differentiation to use
     (see [`Optimization.jl`](https://docs.sciml.ai/Optimization/stable/optimization_packages/optimisers/))
   - `maxiters = 100`: maximum number of iterations before the algorithm stops
@@ -35,14 +36,14 @@ value.
   - `show_progress = false`: whether to print a progress bar
 """
 function min_action_method(
-    sys::ContinuousTimeDynamicalSystem, x_i, x_f, T::Real; points::Int=100, kwargs...
+    sys::ContinuousTimeDynamicalSystem, x_i, x_f, T::Real, optimizer=Optimisers.Adam(); points::Int=100, kwargs...
 )
     init = reduce(hcat, range(x_i, x_f; length=points))
-    return min_action_method(sys, init, T; kwargs...)
+    return min_action_method(sys, init, T, optimizer; kwargs...)
 end;
 
 """
-    min_action_method(sys::ContinuousTimeDynamicalSystem, init::Matrix, T::Real; kwargs...)
+    min_action_method(sys::ContinuousTimeDynamicalSystem, init::Matrix, T::Real, optimizer=Optimisers.Adam(); kwargs...)
 
 Minimizes the specified action functional to obtain a minimum action path (instanton)
 between fixed end points given a system `sys` and total path time `T`.
@@ -51,14 +52,16 @@ The initial path `init` must be a matrix of size `(D, N)`, where `D` is the dime
 of the system and `N` is the number of path points. The physical time of the path
 is specified by `T`, such that the time step between consecutive path points is
 ``\\Delta t = T/N``.
+
+The optional positional argument `optimizer` selects the Optimization.jl solver. It defaults to `Optimisers.Adam()`.
 """
 function min_action_method(
     sys::ContinuousTimeDynamicalSystem,
     init::Matrix{<:Real},
-    T::Real;
+    T::Real,
+    optimizer=Optimisers.Adam();
     functional="FW",
     noise_strength=nothing,
-    optimizer=Optimisers.Adam(),
     ad_type=Optimization.AutoFiniteDiff(),
     maxiters::Int=100,
     abstol::Real=NaN,

--- a/src/largedeviations/min_action_method.jl
+++ b/src/largedeviations/min_action_method.jl
@@ -37,8 +37,8 @@ The optional positional argument `optimizer` selects the Optimization.jl solver.
 """
 function min_action_method(
     sys::ContinuousTimeDynamicalSystem,
-    x_i,
-    x_f,
+    x_i::AbstractVector{<:Real},
+    x_f::AbstractVector{<:Real},
     T::Real,
     optimizer=Optimisers.Adam();
     points::Int=100,

--- a/src/largedeviations/minimize_action.jl
+++ b/src/largedeviations/minimize_action.jl
@@ -1,5 +1,5 @@
 """
-    min_action_method(sys::ContinuousTimeDynamicalSystem, x_i, x_f, T::Real, optimizer=Optimisers.Adam(); kwargs...)
+    minimize_action(sys::ContinuousTimeDynamicalSystem, x_i, x_f, T::Real, optimizer=Optimisers.Adam(); kwargs...)
 
 Minimizes an action functional to obtain a minimum action path (instanton) between an
 initial state `x_i` and final state `x_f` in phase space.
@@ -14,7 +14,7 @@ time via `N` equidistant points and total time `T`. Thus, the time step between
 discretized path points is ``\\Delta t = T/N``.
 To set an initial path different from a straight line, see the multiple dispatch method
 
-> `min_action_method(sys::ContinuousTimeDynamicalSystem, init::Matrix, T::Real, optimizer=Optimisers.Adam(); kwargs...)`.
+> `minimize_action(sys::ContinuousTimeDynamicalSystem, init::Matrix, T::Real, optimizer=Optimisers.Adam(); kwargs...)`.
 
 Returns a [`MinimumActionPath`](@ref) object containing the optimized path and the action
 value.
@@ -35,7 +35,7 @@ The optional positional argument `optimizer` selects the Optimization.jl solver.
   - `verbose = false`: whether to print Optimization information during the run
   - `show_progress = false`: whether to print a progress bar
 """
-function min_action_method(
+function minimize_action(
     sys::ContinuousTimeDynamicalSystem,
     x_i::AbstractVector{<:Real},
     x_f::AbstractVector{<:Real},
@@ -45,11 +45,11 @@ function min_action_method(
     kwargs...,
 )
     init = reduce(hcat, range(x_i, x_f; length=points))
-    return min_action_method(sys, init, T, optimizer; kwargs...)
+    return minimize_action(sys, init, T, optimizer; kwargs...)
 end;
 
 """
-    min_action_method(sys::ContinuousTimeDynamicalSystem, init::Matrix, T::Real, optimizer=Optimisers.Adam(); kwargs...)
+    minimize_action(sys::ContinuousTimeDynamicalSystem, init::Matrix, T::Real, optimizer=Optimisers.Adam(); kwargs...)
 
 Minimizes the specified action functional to obtain a minimum action path (instanton)
 between fixed end points given a system `sys` and total path time `T`.
@@ -61,7 +61,7 @@ is specified by `T`, such that the time step between consecutive path points is
 
 The optional positional argument `optimizer` selects the Optimization.jl solver. It defaults to `Optimisers.Adam()`.
 """
-function min_action_method(
+function minimize_action(
     sys::ContinuousTimeDynamicalSystem,
     init::Matrix{<:Real},
     T::Real,
@@ -113,6 +113,6 @@ end;
 """
     action_minimizer(sys::ContinuousTimeDynamicalSystem, x_i, x_f, T::Real; kwargs...)
 
-Alias for [`min_action_method`](@ref).]
+Alias for [`minimize_action`](@ref).]
 """
-const action_minimizer = min_action_method
+const action_minimizer = minimize_action

--- a/src/largedeviations/minimize_action.jl
+++ b/src/largedeviations/minimize_action.jl
@@ -25,7 +25,7 @@ The optional positional argument `optimizer` selects the Optimization.jl solver.
 
   - `functional = "FW"`: type of action functional to minimize.
     Defaults to [`fw_action`](@ref), alternative: "OM" for [`om_action`](@ref)
-  - `points = 100`: number of path points to use for the discretization of the path
+  - `npoints = 100`: number of path points to use for the discretization of the path
   - `noise_strength = nothing`: noise strength for the action functional. Specify only if `functional = "OM"`
   - `ad_type = Optimization.AutoFiniteDiff()`: type of automatic differentiation to use
     (see [`Optimization.jl`](https://docs.sciml.ai/Optimization/stable/optimization_packages/optimisers/))
@@ -41,10 +41,10 @@ function minimize_action(
     x_f::AbstractVector{<:Real},
     T::Real,
     optimizer=Optimisers.Adam();
-    points::Int=100,
+    npoints::Int=100,
     kwargs...,
 )
-    init = reduce(hcat, range(x_i, x_f; length=points))
+    init = reduce(hcat, range(x_i, x_f; length=npoints))
     return minimize_action(sys, init, T, optimizer; kwargs...)
 end;
 

--- a/src/largedeviations/minimize_geometric_action.jl
+++ b/src/largedeviations/minimize_geometric_action.jl
@@ -1,5 +1,5 @@
 """
-    geometric_min_action_method(sys::CoupledSDEs, x_i, x_f, optimizer=GeometricGradient(); kwargs...)
+    minimize_geometric_action(sys::CoupledSDEs, x_i, x_f, optimizer=GeometricGradient(); kwargs...)
 
 Computes the minimizer of the geometric Freidlin-Wentzell action based on the geometric
 minimum action method (gMAM), using optimizers of Optimization.jl or the original formulation
@@ -8,10 +8,11 @@ descent.
 
 The minimizer is computed for the system `sys` over all paths leading from the initial state
 `x_i` to the final state `x_f`.
-
 To set an initial path different from a straight line, see the multiple dispatch method
 
-  - `geometric_min_action_method(sys::CoupledSDEs, init::Matrix, arclength::Real; kwargs...)`.
+  - `minimize_geometric_action(sys::CoupledSDEs, init::Matrix, arclength::Real; kwargs...)`.
+
+Returns a [`MinimumActionPath`](@ref) object.
 
 ## Keyword arguments
 
@@ -36,7 +37,7 @@ The `optimizer` argument accepts:
 ## Notes
 Only the Freidlin-Wentzell action has a geometric formulation.
 """
-function geometric_min_action_method(
+function minimize_geometric_action(
     sys::ContinuousTimeDynamicalSystem,
     x_i,
     x_f,
@@ -45,7 +46,7 @@ function geometric_min_action_method(
     kwargs...,
 )
     path = reduce(hcat, range(x_i, x_f; length=npoints))
-    return geometric_min_action_method(sys, path, optimizer; kwargs...)
+    return minimize_geometric_action(sys, path, optimizer; kwargs...)
 end
 
 function _gmam_setup(sys, init, maxiters, show_progress)
@@ -61,10 +62,10 @@ function _gmam_setup(sys, init, maxiters, show_progress)
     return path, N, alpha, arc, S, prog
 end
 
-function geometric_min_action_method(
+function minimize_geometric_action(
     sys::ContinuousTimeDynamicalSystem, init::Matrix; kwargs...
 )
-    return geometric_min_action_method(sys, init, GeometricGradient(); kwargs...)
+    return minimize_geometric_action(sys, init, GeometricGradient(); kwargs...)
 end
 
 """
@@ -77,9 +78,9 @@ The initial path `init` must be a matrix of size `(D, N)`, where `D` is the dime
 system and `N` is the number of path points.
 
 For more information see the main method,
-[`geometric_min_action_method(sys::CoupledSDEs, x_i, x_f, arclength::Real; kwargs...)`](@ref).
+[`minimize_geometric_action(sys::CoupledSDEs, x_i, x_f, arclength::Real; kwargs...)`](@ref).
 """
-function geometric_min_action_method(
+function minimize_geometric_action(
     sys::ContinuousTimeDynamicalSystem,
     init::Matrix,
     optimizer::GeometricGradient;
@@ -117,7 +118,7 @@ function geometric_min_action_method(
     return MinimumActionPath(StateSpaceSet(path'), S(path))
 end
 
-function geometric_min_action_method(
+function minimize_geometric_action(
     sys::ContinuousTimeDynamicalSystem,
     init::Matrix,
     optimizer;

--- a/src/largedeviations/sgMAM.jl
+++ b/src/largedeviations/sgMAM.jl
@@ -18,7 +18,7 @@ struct ExtendedPhaseSpace{IIP,D,Hx,Hp}
 
         f = dynamic_rule(ds)
         jac = jacobian(ds)
-        param=current_parameters(ds)
+        param = current_parameters(ds)
 
         function H_x(x, p) # ℜ² → ℜ²
             Hx = similar(x)
@@ -80,7 +80,8 @@ The implementation is based on the work of [Grafke et al. (2019)](https://homepa
 """
 function simple_geometric_min_action_method(
     sys::ExtendedPhaseSpace,
-    x_initial::Matrix{T};
+    x_initial::Matrix{T},
+    optimizer::GMAMOptimizer=GeometricGradient();
     stepsize::Real=1e-1,
     maxiters::Int=1000,
     show_progress::Bool=false,
@@ -123,14 +124,21 @@ function simple_geometric_min_action_method(
         StateSpaceSet(x'), S[end]; λ=lambda, generalized_momentum=p, path_velocity=xdot
     )
 end
-function simple_geometric_min_action_method(sys, x_initial::StateSpaceSet; kwargs...)
-    return simple_geometric_min_action_method(sys, Matrix(Matrix(x_initial)'); kwargs...)
-end
 function simple_geometric_min_action_method(
-    sys::ContinuousTimeDynamicalSystem, x_initial::Matrix{<:Real}; kwargs...
+    sys, x_initial::StateSpaceSet, optimizer::GMAMOptimizer=GeometricGradient(); kwargs...
 )
     return simple_geometric_min_action_method(
-        ExtendedPhaseSpace(sys), Matrix(Matrix(x_initial)'); kwargs...
+        sys, Matrix(Matrix(x_initial)'), optimizer; kwargs...
+    )
+end
+function simple_geometric_min_action_method(
+    sys::ContinuousTimeDynamicalSystem,
+    x_initial::Matrix{<:Real},
+    optimizer::GMAMOptimizer=GeometricGradient();
+    kwargs...,
+)
+    return simple_geometric_min_action_method(
+        ExtendedPhaseSpace(sys), Matrix(Matrix(x_initial)'), optimizer; kwargs...
     )
 end
 

--- a/src/largedeviations/sgMAM.jl
+++ b/src/largedeviations/sgMAM.jl
@@ -80,7 +80,7 @@ step size is set via `GeometricGradient(; stepsize=...)`.
   - `abstol::Real=NaN`: absolute tolerance for early stopping based on action change
   - `reltol::Real=NaN`: relative tolerance for early stopping based on action change
 """
-function simple_geometric_min_action_method(
+function minimize_simple_geometric_action(
     sys::ExtendedPhaseSpace,
     x_initial::Matrix{T},
     optimizer::GeometricGradient=GeometricGradient(; stepsize=1e-1);
@@ -125,23 +125,23 @@ function simple_geometric_min_action_method(
         StateSpaceSet(x'), S[end]; λ=lambda, generalized_momentum=p, path_velocity=xdot
     )
 end
-function simple_geometric_min_action_method(
+function minimize_simple_geometric_action(
     sys,
     x_initial::StateSpaceSet,
     optimizer::GeometricGradient=GeometricGradient(; stepsize=1e-1);
     kwargs...,
 )
-    return simple_geometric_min_action_method(
+    return minimize_simple_geometric_action(
         sys, Matrix(Matrix(x_initial)'), optimizer; kwargs...
     )
 end
-function simple_geometric_min_action_method(
+function minimize_simple_geometric_action(
     sys::ContinuousTimeDynamicalSystem,
     x_initial::Matrix{<:Real},
     optimizer::GeometricGradient=GeometricGradient(; stepsize=1e-1);
     kwargs...,
 )
-    return simple_geometric_min_action_method(
+    return minimize_simple_geometric_action(
         ExtendedPhaseSpace(sys), Matrix(Matrix(x_initial)'), optimizer; kwargs...
     )
 end

--- a/src/largedeviations/sgMAM.jl
+++ b/src/largedeviations/sgMAM.jl
@@ -61,17 +61,19 @@ Our implementation is only valid for additive noise.
 This method computes the optimal path in the phase space of a Hamiltonian system that
 minimizes the Freidlin–Wentzell action. The Hamiltonian functions `H_x` and `H_p` define
 the system's dynamics in a doubled phase. The initial state `x_initial` is evolved
-iteratively using constrained gradient descent with step size parameter `stepsize` over a specified
-number of iterations. The method can display a progress meter and will stop early if the
-absolute tolerance `abstol` or relative tolerance `reltol` is achieved.
+iteratively using constrained gradient descent over a specified number of iterations. The
+method can display a progress meter and will stop early if the absolute tolerance
+`abstol` or relative tolerance `reltol` is achieved.
 
 The function returns a [`MinimumActionPath`](@ref) containing the final path, the action value,
 the Lagrange multipliers (`.λ`), the momentum (`.generalized_momentum`), and the state derivatives (`.path_velocity`).
 The implementation is based on the work of [Grafke et al. (2019)](https://homepages.warwick.ac.uk/staff/T.Grafke/simplified-geometric-minimum-action-method-for-the-computation-of-instantons.html).
 
+The optional positional argument `optimizer` configures the projected-gradient update. The
+step size is set via `GeometricGradient(; stepsize=...)`.
+
 ## Keyword arguments
 
-  - `stepsize::Real=1e-1`: step size for gradient descent. Default: `0.1`
   - `maxiters::Int=1000`: maximum number of iterations before the algorithm stops
   - `show_progress::Bool=false`: if true, display a progress bar
   - `verbose::Bool=false`: if true, print additional output
@@ -81,8 +83,7 @@ The implementation is based on the work of [Grafke et al. (2019)](https://homepa
 function simple_geometric_min_action_method(
     sys::ExtendedPhaseSpace,
     x_initial::Matrix{T},
-    optimizer::GMAMOptimizer=GeometricGradient();
-    stepsize::Real=1e-1,
+    optimizer::GeometricGradient=GeometricGradient(; stepsize=1e-1);
     maxiters::Int=1000,
     show_progress::Bool=false,
     verbose::Bool=false,
@@ -101,7 +102,7 @@ function simple_geometric_min_action_method(
 
     progress = Progress(maxiters; dt=0.5, enabled=show_progress)
     for i in 1:maxiters
-        update!(x, xdot, xdotdot, p, pdot, lambda, H_x, H_p, stepsize)
+        update!(x, xdot, xdotdot, p, pdot, lambda, H_x, H_p, optimizer.stepsize)
 
         # reparameterize to arclength
         interpolate_path!(x, alpha, s)
@@ -125,7 +126,10 @@ function simple_geometric_min_action_method(
     )
 end
 function simple_geometric_min_action_method(
-    sys, x_initial::StateSpaceSet, optimizer::GMAMOptimizer=GeometricGradient(); kwargs...
+    sys,
+    x_initial::StateSpaceSet,
+    optimizer::GeometricGradient=GeometricGradient(; stepsize=1e-1);
+    kwargs...,
 )
     return simple_geometric_min_action_method(
         sys, Matrix(Matrix(x_initial)'), optimizer; kwargs...
@@ -134,7 +138,7 @@ end
 function simple_geometric_min_action_method(
     sys::ContinuousTimeDynamicalSystem,
     x_initial::Matrix{<:Real},
-    optimizer::GMAMOptimizer=GeometricGradient();
+    optimizer::GeometricGradient=GeometricGradient(; stepsize=1e-1);
     kwargs...,
 )
     return simple_geometric_min_action_method(

--- a/test/largedeviations/API.jl
+++ b/test/largedeviations/API.jl
@@ -15,8 +15,8 @@
     init = reduce(hcat, range(x_i, x_f; length=N))
 
     for inst in [corr_alt, addit_non_autom, linear_multipli]
-        @test_throws ArgumentError min_action_method(inst, init, T)
-        @test_throws ArgumentError geometric_min_action_method(inst, init)
-        @test_throws ArgumentError simple_geometric_min_action_method(inst, init)
+        @test_throws ArgumentError minimize_action(inst, init, T)
+        @test_throws ArgumentError minimize_geometric_action(inst, init)
+        @test_throws ArgumentError minimize_simple_geometric_action(inst, init)
     end
 end

--- a/test/largedeviations/MAM.jl
+++ b/test/largedeviations/MAM.jl
@@ -10,7 +10,7 @@ using CriticalTransitions.CTLibrary: fitzhugh_nagumo
     x_i = SA[sqrt(2 / 3), sqrt(2 / 27)]
     x_f = SA[0.001, 0.0]
     N, T = 200, 2.0
-    inst = min_action_method(fhn, x_i, x_f, T; points=N, maxiters=500, show_progress=false)
+    inst = min_action_method(fhn, x_i, x_f, T; npoints=N, maxiters=500, show_progress=false)
     # If you evolve for longer the path splits into two :/
     S = fw_action(fhn, Matrix(inst.path)', range(0.0, T; length=N))
     @test isapprox(S, 0.18, atol=0.01)
@@ -25,7 +25,7 @@ end
     N = 51
     t = range(0, T, N)
     inst_mam = min_action_method(
-        ou, SA[x0], SA[xT], T; points=51, maxiters=2000, show_progress=false
+        ou, SA[x0], SA[xT], T; npoints=51, maxiters=2000, show_progress=false
     )
     inst_sol =
         ((xT - x0 * exp(-T)) * exp.(t) .+ (x0 * exp(T) - xT) * exp.(-t)) /

--- a/test/largedeviations/MAM.jl
+++ b/test/largedeviations/MAM.jl
@@ -10,7 +10,7 @@ using CriticalTransitions.CTLibrary: fitzhugh_nagumo
     x_i = SA[sqrt(2 / 3), sqrt(2 / 27)]
     x_f = SA[0.001, 0.0]
     N, T = 200, 2.0
-    inst = min_action_method(fhn, x_i, x_f, T; npoints=N, maxiters=500, show_progress=false)
+    inst = minimize_action(fhn, x_i, x_f, T; npoints=N, maxiters=500, show_progress=false)
     # If you evolve for longer the path splits into two :/
     S = fw_action(fhn, Matrix(inst.path)', range(0.0, T; length=N))
     @test isapprox(S, 0.18, atol=0.01)
@@ -24,7 +24,7 @@ end
     T = 10.0
     N = 51
     t = range(0, T, N)
-    inst_mam = min_action_method(
+    inst_mam = minimize_action(
         ou, SA[x0], SA[xT], T; npoints=51, maxiters=2000, show_progress=false
     )
     inst_sol =

--- a/test/largedeviations/Maier_stein.jl
+++ b/test/largedeviations/Maier_stein.jl
@@ -33,10 +33,10 @@ using Test
     end
 
     @testset "Adam" begin
-        gm = geometric_min_action_method(
+        gm = minimize_geometric_action(
             sys, x_i, x_f; maxiters=10, verbose=false, show_progress=false
         )
-        gm = geometric_min_action_method(
+        gm = minimize_geometric_action(
             sys, init; maxiters=500, verbose=false, show_progress=false
         )
 
@@ -50,7 +50,7 @@ using Test
         import CriticalTransitions as CT
         S(x) = geometric_action(sys, CT.fix_ends(x, init[:, 1], init[:, end]), 1.0)
 
-        gm = geometric_min_action_method(
+        gm = minimize_geometric_action(
             sys, init; maxiters=500, verbose=false, show_progress=false
         )
         string = string_method(

--- a/test/largedeviations/action_limit_cycle.jl
+++ b/test/largedeviations/action_limit_cycle.jl
@@ -61,13 +61,7 @@ end
 
     # Start from a straight-line initial path; minimizer should move it onto the LC segment.
     res = geometric_min_action_method(
-        sys,
-        x_i,
-        x_f;
-        points=500,
-        maxiters=1000,
-        show_progress=false,
-        verbose=false,
+        sys, x_i, x_f; points=500, maxiters=1000, show_progress=false, verbose=false
     )
 
     S = res.action

--- a/test/largedeviations/action_limit_cycle.jl
+++ b/test/largedeviations/action_limit_cycle.jl
@@ -66,7 +66,6 @@ end
         x_f;
         points=500,
         maxiters=1000,
-        optimizer=GeometricGradient(),
         show_progress=false,
         verbose=false,
     )

--- a/test/largedeviations/action_limit_cycle.jl
+++ b/test/largedeviations/action_limit_cycle.jl
@@ -60,7 +60,7 @@ end
     x_f = SA[0.0, 1.0]
 
     # Start from a straight-line initial path; minimizer should move it onto the LC segment.
-    res = geometric_min_action_method(
+    res = minimize_geometric_action(
         sys, x_i, x_f; npoints=500, maxiters=1000, show_progress=false, verbose=false
     )
 

--- a/test/largedeviations/action_limit_cycle.jl
+++ b/test/largedeviations/action_limit_cycle.jl
@@ -61,7 +61,7 @@ end
 
     # Start from a straight-line initial path; minimizer should move it onto the LC segment.
     res = geometric_min_action_method(
-        sys, x_i, x_f; points=500, maxiters=1000, show_progress=false, verbose=false
+        sys, x_i, x_f; npoints=500, maxiters=1000, show_progress=false, verbose=false
     )
 
     S = res.action

--- a/test/largedeviations/gMAM.jl
+++ b/test/largedeviations/gMAM.jl
@@ -35,11 +35,7 @@ end
     x_f = init[:, end]
 
     gm = geometric_min_action_method(
-        sys,
-        init, GeometricGradient();
-        maxiters=500,
-        verbose=false,
-        show_progress=false,
+        sys, init, GeometricGradient(); maxiters=500, verbose=false, show_progress=false
     )
 
     path = Matrix(gm.path)'

--- a/test/largedeviations/gMAM.jl
+++ b/test/largedeviations/gMAM.jl
@@ -36,9 +36,8 @@ end
 
     gm = geometric_min_action_method(
         sys,
-        init;
+        init, GeometricGradient();
         maxiters=500,
-        optimizer=GeometricGradient(),
         verbose=false,
         show_progress=false,
     )

--- a/test/largedeviations/gMAM.jl
+++ b/test/largedeviations/gMAM.jl
@@ -43,3 +43,13 @@ end
     @test all(isapprox.(path[2, :][(end - 5):end], 0, atol=1e-3))
     @test all(isapprox.(action_val, 0.3375, atol=1e-3))
 end # GeometricGradient
+
+@testset "GeometricGradient constructor" begin
+    opt = GeometricGradient()
+    @test opt.stepsize isa Float64
+    @test opt.stepsize == 0.01
+
+    opt2 = GeometricGradient(; stepsize=1)
+    @test opt2.stepsize isa Float64
+    @test opt2.stepsize == 1.0
+end

--- a/test/largedeviations/gMAM.jl
+++ b/test/largedeviations/gMAM.jl
@@ -10,7 +10,7 @@ using CriticalTransitions.CTLibrary: fitzhugh_nagumo
     x_i = SA[sqrt(2 / 3), sqrt(2 / 27)]
     x_f = SA[0.001, 0.0]
     res = geometric_min_action_method(
-        fhn, x_i, x_f; points=30, maxiters=500, show_progress=false
+        fhn, x_i, x_f; npoints=30, maxiters=500, show_progress=false
     )
     S = geometric_action(fhn, Matrix(res.path)')
     @test isapprox(S, 0.18, atol=0.01)

--- a/test/largedeviations/gMAM.jl
+++ b/test/largedeviations/gMAM.jl
@@ -9,7 +9,7 @@ using CriticalTransitions.CTLibrary: fitzhugh_nagumo
     fhn = CoupledSDEs(fitzhugh_nagumo, zeros(2), p; noise_strength=σ)
     x_i = SA[sqrt(2 / 3), sqrt(2 / 27)]
     x_f = SA[0.001, 0.0]
-    res = geometric_min_action_method(
+    res = minimize_geometric_action(
         fhn, x_i, x_f; npoints=30, maxiters=500, show_progress=false
     )
     S = geometric_action(fhn, Matrix(res.path)')
@@ -34,7 +34,7 @@ end
     x_i = init[:, 1]
     x_f = init[:, end]
 
-    gm = geometric_min_action_method(
+    gm = minimize_geometric_action(
         sys, init, GeometricGradient(); maxiters=500, verbose=false, show_progress=false
     )
 

--- a/test/largedeviations/sgMAM.jl
+++ b/test/largedeviations/sgMAM.jl
@@ -94,3 +94,22 @@ end
     @test sys.H_x(zeros(2), zeros(2)) ≈ zeros(2)
     @test sys.H_p(zeros(2), zeros(2)) ≈ zeros(2)
 end
+
+@testset "sgMAM GeometricGradient" begin
+    H_x(x, p) = zeros(size(x))
+    H_p(x, p) = ones(size(x))
+    sys = ExtendedPhaseSpace{false,2}(H_x, H_p)
+
+    xx = collect(range(-1.0, 1.0; length=20))
+    yy = 0.3 .* (-xx .^ 2 .+ 1)
+    x_initial = Matrix([xx yy]')
+
+    res_small = simple_geometric_min_action_method(
+        sys, x_initial, GeometricGradient(; stepsize=1e-6); maxiters=2, show_progress=false
+    )
+    res_large = simple_geometric_min_action_method(
+        sys, x_initial, GeometricGradient(; stepsize=1.0); maxiters=2, show_progress=false
+    )
+
+    @test res_small.action != res_large.action
+end

--- a/test/largedeviations/sgMAM.jl
+++ b/test/largedeviations/sgMAM.jl
@@ -104,10 +104,10 @@ end
     yy = 0.3 .* (-xx .^ 2 .+ 1)
     x_initial = Matrix([xx yy]')
 
-    res_small = simple_geometric_min_action_method(
+    res_small = minimize_simple_geometric_action(
         sys, x_initial, GeometricGradient(; stepsize=1e-6); maxiters=2, show_progress=false
     )
-    res_large = simple_geometric_min_action_method(
+    res_large = minimize_simple_geometric_action(
         sys, x_initial, GeometricGradient(; stepsize=1.0); maxiters=2, show_progress=false
     )
 


### PR DESCRIPTION
Move the optimization algorithm selection from keyword arguments to a type-based dispatch system. Instead of passing `optimizer` and `stepsize` as separate kwargs, callers now pass a typed optimizer object (e.g. `GeometricGradient(; stepsize=1e3))` as a positional argument. This applies to `geometric_min_action_method`, `simple_geometric_min_action_method`, and `min_action_method`.

This enables dispatching on optimizer type, which is the foundation for adding a stepsize controller in #268.