### PR TITLE
build(deps): pin StochasticDiffEq version :/

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -65,7 +65,7 @@ SparseArrays = "1.10"
 StateSpaceSets = "2.3.0"
 StaticArrays = "1.9.8"
 Statistics = ">=1.9"
-StochasticDiffEq = "6.71, 6.96"
+StochasticDiffEq = "6.71, < 6.96"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -65,7 +65,7 @@ SparseArrays = "1.10"
 StateSpaceSets = "2.3.0"
 StaticArrays = "1.9.8"
 Statistics = ">=1.9"
-StochasticDiffEq = "6.71"
+StochasticDiffEq = "6.71, 6.96"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -65,7 +65,7 @@ SparseArrays = "1.10"
 StateSpaceSets = "2.3.0"
 StaticArrays = "1.9.8"
 Statistics = ">=1.9"
-StochasticDiffEq = "6.71, < 6.96"
+StochasticDiffEq = "6.71 - 6.95"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
https://github.com/SciML/StochasticDiffEq.jl/pull/684

where .g no longer exists on the integrator — it's now accessed via .f.g.