### PR TITLE
feat: implement large deviation for multiplicative noise

### DIFF
--- a/benchmarks/implementation_benchmarks/KPO_sgMAM.jl
+++ b/benchmarks/implementation_benchmarks/KPO_sgMAM.jl
@@ -43,7 +43,7 @@ function H_p(x, p) # ℜ² → ℜ²
     return Matrix([H_pu H_pv]')
 end
 
-sys = ExtendedPhaseSpace{false, 2}(H_x, H_p)
+sys = FreidlinWentzellHamiltonian{false, 2}(H_x, H_p)
 sgmam_opt = GeometricGradient(; max_backtracks = 0, stepsize = 10.0e2)
 
 # setup

--- a/benchmarks/implementation_benchmarks/evaluate_drift.jl
+++ b/benchmarks/implementation_benchmarks/evaluate_drift.jl
@@ -51,7 +51,7 @@ function H_p(x, p) # ℜ² → ℜ²
     return Matrix([H_pu H_pv]')
 end
 
-sys_m = ExtendedPhaseSpace{false, 2}(H_x, H_p)
+sys_m = FreidlinWentzellHamiltonian{false, 2}(H_x, H_p)
 
 x_init_m = Matrix([xx yy]')
 
@@ -78,7 +78,7 @@ ds = CoupledODEs(prob)
 jac = jacobian(ds)
 jac([1, 1], (), 0.0)
 
-sgSys′ = ExtendedPhaseSpace(ds);
+sgSys′ = FreidlinWentzellHamiltonian(ds);
 
 p_r = rand(2, Nt)
 sgSys′.H_x(x_init_m, p_r) ≈ sys_m.H_x(x_init_m, p_r)

--- a/benchmarks/implementation_benchmarks/string_method.jl
+++ b/benchmarks/implementation_benchmarks/string_method.jl
@@ -61,7 +61,7 @@ function sss()
         return StateSpaceSet(permutedims(Matrix([H_pu H_pv]')))
     end
 
-    sys_sss = ExtendedPhaseSpace{false, 2}(H_x, H_p)
+    sys_sss = FreidlinWentzellHamiltonian{false, 2}(H_x, H_p)
 
     x_init_sss = StateSpaceSet([xx yy])
     return sys_sss, x_init_sss
@@ -85,7 +85,7 @@ function m()
         return Matrix([H_pu H_pv]')
     end
 
-    sys_m = ExtendedPhaseSpace{false, 2}(H_x, H_p)
+    sys_m = FreidlinWentzellHamiltonian{false, 2}(H_x, H_p)
 
     x_init_m = Matrix([xx yy]')
     return sys_m, x_init_m

--- a/benchmarks/kpo.jl
+++ b/benchmarks/kpo.jl
@@ -39,7 +39,7 @@ function benchmark_KPO!(SUITE)
         return Matrix([H_pu H_pv]')
     end
 
-    sys = ExtendedPhaseSpace{false, 2}(H_x, H_p)
+    sys = FreidlinWentzellHamiltonian{false, 2}(H_x, H_p)
 
     Nt = 100  # number of discrete time steps
     s = collect(range(0; stop = 1, length = Nt))

--- a/docs/src/examples/sgMAM_KPO.md
+++ b/docs/src/examples/sgMAM_KPO.md
@@ -63,10 +63,10 @@ function H_p(x, p) # ℜ² → ℜ²
     return Matrix([H_pu H_pv]')
 end
 
-sys = ExtendedPhaseSpace{false,2}(H_x, H_p)
+sys = FreidlinWentzellHamiltonian{false,2}(H_x, H_p)
 ````
 
-We saved this function in the `ExtendedPhaseSpace` struct. We want to find the optimal path between two attractors in the phase space. We define the initial trajectory as `wiggle` between the two attractors.
+We saved this function in the `FreidlinWentzellHamiltonian` struct. We want to find the optimal path between two attractors in the phase space. We define the initial trajectory as `wiggle` between the two attractors.
 
 ````@example sgMAM_KPO
 Nt = 500  # number of discrete time steps

--- a/docs/src/man/largedeviations.md
+++ b/docs/src/man/largedeviations.md
@@ -5,11 +5,54 @@ This section applies results of large deviation theory (LDT), particularly actio
 !!! info
     The methods in this section apply to ``D``-dimensional stochastic dynamical systems of the form
     ```math
-    \text{d} \mathbf{x} = \mathbf{b} (\mathbf{x}) \text{d}t + \sigma \mathbf{\Sigma} \text{d}\mathbf{W}_t \,,
+    \text{d} \mathbf{x} = \mathbf{b} (\mathbf{x}) \text{d}t + \sqrt{\varepsilon}\, \mathbf{\sigma}(\mathbf{x}) \text{d}\mathbf{W}_t \,,
     ```
-    where the drift field ``\mathbf{b}`` may be non-gradient but the noise term must consist of Gaussian noise (``\mathbf{W}_t`` is a ``D``-dimensional vector of independent standard Wiener processes) and a constant covariance matrix ``\mathbf{Q} = \mathbf{\Sigma}\mathbf{\Sigma}^\top``.
+    where the drift field ``\mathbf{b}`` may be non-gradient and the noise term consists of Gaussian noise (``\mathbf{W}_t`` is a ``D``-dimensional vector of independent standard Wiener processes). The diffusion ``\mathbf{\sigma}(\mathbf{x})`` may be state-dependent; we write ``\mathbf{a}(\mathbf{x}) = \mathbf{\sigma}(\mathbf{x})\mathbf{\sigma}(\mathbf{x})^\top`` for the noise covariance tensor. The action-minimization routines below dispatch automatically on the system's noise traits: additive noise uses a constant normalized covariance; multiplicative noise evaluates ``\mathbf{a}(\mathbf{x})`` from the `CoupledSDEs` diffusion function at each path point.
 
     This is a special case of the broader class of noise types supported by [`CoupledSDEs`](@ref).
+
+## Hamiltonian picture
+
+In the weak-noise limit, the Freidlin-Wentzell rate function for a path ``\varphi(t)`` from
+``x_i`` to ``x_f`` can be written in two equivalent forms.
+
+**Lagrangian form.** Directly from the SDE,
+
+```math
+S[\varphi] \;=\; \tfrac{1}{2} \int_0^T \langle \dot\varphi - \mathbf{b}(\varphi),\, \mathbf{a}(\varphi)^{-1}(\dot\varphi - \mathbf{b}(\varphi)) \rangle \, \mathrm{d}t \,.
+```
+
+The factor ``1/2`` is part of the definition and lives inside [`fw_action`](@ref).
+
+**Hamiltonian form.** Introduce the conjugate momentum ``p`` via the Legendre transform.
+The associated Hamiltonian is
+
+```math
+H(\varphi, p) \;=\; \langle \mathbf{b}(\varphi),\, p \rangle + \tfrac{1}{2}\, \langle p,\, \mathbf{a}(\varphi)\, p \rangle \,,
+```
+
+with derivatives
+
+```math
+H_p(\varphi, p) = \mathbf{b}(\varphi) + \mathbf{a}(\varphi)\,p \,, \quad
+H_\varphi(\varphi, p) = (\partial_\varphi \mathbf{b})^\top p + \tfrac{1}{2}\langle p,\, (\partial_\varphi \mathbf{a})\, p \rangle \,, \quad
+H_{pp}(\varphi, p) = \mathbf{a}(\varphi) \,.
+```
+
+The action along an instanton (where ``H \equiv 0``) reduces to
+
+```math
+S[\varphi] \;=\; \int_0^T \langle p, \dot\varphi \rangle\, \mathrm{d}t \,.
+```
+
+This is the form used by the [`sgMAM`](#Simple-geometric-minimum-action-method-(sgMAM))
+solver, encoded in the [`FreidlinWentzellHamiltonian`](@ref) struct that stores
+``H_x`` and ``H_p`` directly. Note that the ``1/2`` from the Lagrangian form is absorbed
+into the zero-energy condition, so the Hamiltonian-form integrand has no explicit factor of
+``1/2`` (and the implementation in [`CriticalTransitions.FW_action`](@ref) reflects this).
+In the additive case ``\mathbf{a} \equiv \mathbf{I}``, this reduces to the familiar
+``H = \langle \mathbf{b}, p\rangle + \tfrac{1}{2}\lVert p\rVert^2``.
+
 
 ## Action minimizers
 Several methods have been proposed to calculate transition paths that minimize a given [action functional](@ref "Action functionals"). In the weak-noise limit, this minimum action path (or instanton) corresponds to the most probable transition path. While the minimum action method (MAM) is the most basic version, it is often beneficial to minimize the [geometric action](@ref "Geometric Freidlin-Wentzell action") via a time-independent version called gMAM. The problem can also be cast in a Hamiltonian form, implemented as simple gMAM (sgMAM), which can have numerical advantages.
@@ -25,9 +68,9 @@ To summarize, the following methods are available:
 
 | Method | Use when | Requirements (this package) | Not suitable when |
 |---|---|---|---|
-| **MAM** | You want a **minimum action path** for a specified travel time $T$ (FW/OM action minimization). | `CoupledSDEs` with **additive**, **invertible**, **autonomous** noise (constant covariance); discretized path uses **equispaced time**. | **Multiplicative/state-dependent noise**, **degenerate/non-invertible** noise, **non-autonomous** noise; when the transition time is unknown and you want a time-reparameterization-invariant formulation (prefer gMAM/sgMAM). |
-| **gMAM** | You want a **time-reparameterization-invariant** minimum action path (no explicit optimization over $T$). | Same as MAM for `CoupledSDEs`: **additive**, **invertible**, **autonomous** noise (constant covariance). | **Multiplicative/state-dependent**, **degenerate**, or **non-autonomous** noise; if you need the Onsager--Machlup functional (only FW has a geometric formulation). |
-| **sgMAM** | You want a **Hamiltonian/simple gMAM** formulation that can be efficient in practice. | Same as MAM **and** **diagonal** noise covariance (implementation restriction); assumes **additive** noise. | **Non-diagonal** covariance; **multiplicative/state-dependent** or **degenerate** noise; models where the required derivatives/Jacobian are not available or are too expensive. |
+| **MAM** | You want a **minimum action path** for a specified travel time $T$ (FW/OM action minimization). | `CoupledSDEs` with **autonomous** noise (and **invertible** if additive). The action automatically uses the constant covariance for additive noise and evaluates ``a(x) = \sigma(x)\sigma(x)^\top`` at each path point for multiplicative noise. Discretized path uses **equispaced time**. | **Non-autonomous** noise; OM functional with multiplicative noise (the Onsager-Machlup divergence correction for state-dependent ``a`` is not implemented); when the transition time is unknown (prefer gMAM/sgMAM). |
+| **gMAM** | You want a **time-reparameterization-invariant** minimum action path (no explicit optimization over $T$). | Same as MAM. The dedicated `GeometricGradient` projected-gradient solver now handles state-dependent ``a(x)`` directly: additive noise uses a single tridiagonal solve, diagonal multiplicative noise a per-DOF tridiagonal, and non-diagonal multiplicative noise a sparse block-tridiagonal solve, all with a finite-difference ``\partial_x a`` correction in the descent RHS. | **Non-autonomous** noise; if you need the Onsager-Machlup functional (only FW has a geometric formulation). |
+| **sgMAM** | You want a **Hamiltonian/simple gMAM** formulation that can be efficient in practice. | A [`FreidlinWentzellHamiltonian`](@ref) (formerly `ExtendedPhaseSpace`) with first-order derivatives `H_x`, `H_p`. The convenience constructor on `CoupledSDEs` handles additive, diagonal multiplicative, and general multiplicative noise; the iteration picks the cheapest valid path (shared tridiagonal / per-DOF tridiagonal / sparse block-tridiagonal). | **Non-autonomous** noise; models where the required derivatives of `H` are not available. |
 | **String method** | You want a **minimum energy path / heteroclinic orbit** driven by the deterministic drift (typical use: **gradient** systems). | Deterministic drift field (works for `ContinuousTimeDynamicalSystem`; does not rely on an SDE noise model). | In **non-gradient** systems if you need the *most probable* noise-induced transition path (string gives the deterministic heteroclinic orbit, which generally differs from the instanton). |
 
 #### Variants and extensions
@@ -36,7 +79,7 @@ The literature contains a number of extensions of MAM-type methods that may be r
 - **tMAM / optimal linear time scaling**: avoids explicit optimization over the transition time by introducing an optimal linear time scaling; can be combined with adaptivity in time discretization [wan_tmam_2015](@citet).
 - **Adaptive MAM**: uses a moving-mesh strategy to concentrate grid points in dynamically important portions of the path, improving efficiency and robustness [zhou_adaptive_mam_2008](@citet).
 - **Non-Gaussian (jump / Lévy) noise**: for systems driven by jump noise, the rate function and path optimization problem differ from the Freidlin--Wentzell diffusive setting; see e.g. an optimal-control-based approach in [wei_most_likely_jumps_2023](@citet).
-- **Multiplicative / state-dependent noise**: extensions of geometric action minimization to degenerate or multiplicative noise are discussed in [grafke_small_random_2017](@citet); the current `sgMAM` implementation assumes additive noise.
+- **Multiplicative / state-dependent noise**: following [grafke_long_2017](@citet) (Section 3.5), the geometric / simple-geometric solvers now handle general invertible state-dependent ``a(x)``. [`fw_action`](@ref), [`geometric_action`](@ref), [`minimize_action`](@ref), [`minimize_geometric_action`](@ref) (both the `GeometricGradient` and Optimization.jl paths), and [`minimize_simple_geometric_action`](@ref) automatically use the diffusion tensor ``a(x) = \sigma(x)\sigma(x)^\top`` from the `CoupledSDEs` when the noise is non-additive, with a finite-difference ``\partial_x a`` correction in the descent RHS where required.
 
 ### Minimum action method (MAM)
 Minimization of the specified action functional using the optimization algorithm of `Optimization.jl`. See also [e_minimum_2004](@citet).
@@ -56,10 +99,24 @@ minimize_geometric_action
 Simplified minimization of the geometric action following [grafke_long_2017](@citet).
 The simple gMAM reduces the complexity of the original gMAM by requiring only first-order derivatives of the underlying Hamiltonian optimization formulation. This simplifies the numerical treatment and computational complexity.
 
-The implementation below performs a constrained gradient descent assuming an autonomous system with additive Gaussian noise.
+The implementation performs a constrained gradient descent for an autonomous system. The
+Hamiltonian ``H(x,p) = \langle b(x), p\rangle + \tfrac{1}{2}\langle p, a(x)\, p\rangle``
+is stored in a [`FreidlinWentzellHamiltonian`](@ref) (the type formerly known as
+`ExtendedPhaseSpace`, which remains available as a deprecated alias). The iteration
+auto-dispatches on the structure of ``a(x)``:
+
+* additive (`a ≡ I`): one tridiagonal solve shared across degrees of freedom;
+* diagonal multiplicative (`a(x)` diagonal): per-DOF tridiagonal with coefficient
+  ``\lambda_i^2/a_{kk}(x_i)``;
+* general multiplicative (`a(x)` full): sparse block-tridiagonal solve of size
+  ``(N-2)D \times (N-2)D``.
+
+The convenience constructor `FreidlinWentzellHamiltonian(ds::CoupledSDEs)` picks the
+cheapest valid path automatically and adds the ``\tfrac{1}{2}p^\top(\partial_x a)p`` term
+to ``H_x`` via central finite differences on ``a``.
 ```@docs
 minimize_simple_geometric_action
-ExtendedPhaseSpace
+FreidlinWentzellHamiltonian
 ```
 
 
@@ -69,8 +126,8 @@ sgMAM repeatedly evaluates `H_p(x, p)` and `H_x(x, p)` along a discretized path.
 
 Key reason for performance differences:
 
-- `ExtendedPhaseSpace(ds::CoupledSDEs)` typically relies on `jacobian(ds)` (often automatic differentiation unless you provide an analytic Jacobian) and evaluates it pointwise along the path.
-- A hardcoded `ExtendedPhaseSpace(H_x, H_p)` with analytic expressions operating on the full `D×Nt` path matrix usually allocates far less.
+- `FreidlinWentzellHamiltonian(ds::CoupledSDEs)` typically relies on `jacobian(ds)` (often automatic differentiation unless you provide an analytic Jacobian) and evaluates it pointwise along the path.
+- A hardcoded `FreidlinWentzellHamiltonian{false,D}(H_x, H_p)` with analytic expressions operating on the full `D×Nt` path matrix usually allocates far less.
 
 Benchmark pattern:
 
@@ -78,17 +135,17 @@ Benchmark pattern:
 using CriticalTransitions
 using BenchmarkTools
 
-sys_fast = ExtendedPhaseSpace{false,2}(H_x, H_p)  # hardcoded analytic H_x/H_p
+sys_fast = FreidlinWentzellHamiltonian{false,2}(H_x, H_p)  # hardcoded analytic H_x/H_p
 
 ds = CoupledSDEs(KPO, zeros(2), ())
-sys_generic = ExtendedPhaseSpace(ds)              # uses jacobian(ds)
+sys_generic = FreidlinWentzellHamiltonian(ds)              # uses jacobian(ds)
 
 opt = GeometricGradient(; stepsize=0.5)
 @btime minimize_simple_geometric_action($sys_fast,    $x_initial, $opt; maxiters=100, show_progress=false)
 @btime minimize_simple_geometric_action($sys_generic, $x_initial, $opt; maxiters=100, show_progress=false)
 ```
 
-Aside: the same “vectorized + allocation-free inner loop” principle also tends to make [`string_method`](@ref) faster when used with `ExtendedPhaseSpace`.
+Aside: the same "vectorized + allocation-free inner loop" principle also tends to make [`string_method`](@ref) faster when used with `FreidlinWentzellHamiltonian`.
 
 ### `MinimumActionPath`
 [(gMAM)](@ref "Geometric minimum action method (gMAM)") and [(sgMAM)](@ref "Simple geometric minimum action method (sgMAM)") return their output as a `MinimumActionPath` type:

--- a/docs/src/man/largedeviations.md
+++ b/docs/src/man/largedeviations.md
@@ -66,12 +66,12 @@ To summarize, the following methods are available:
 - Simple geometric minimum action method [(sgMAM)](@ref "Simple geometric minimum action method (sgMAM)")
 - [String method](@ref)
 
-| Method | Use when | Requirements (this package) | Not suitable when |
+| Method | Use when | Needs | Skip if |
 |---|---|---|---|
-| **MAM** | You want a **minimum action path** for a specified travel time $T$ (FW/OM action minimization). | `CoupledSDEs` with **autonomous** noise (and **invertible** if additive). The action automatically uses the constant covariance for additive noise and evaluates ``a(x) = \sigma(x)\sigma(x)^\top`` at each path point for multiplicative noise. Discretized path uses **equispaced time**. | **Non-autonomous** noise; OM functional with multiplicative noise (the Onsager-Machlup divergence correction for state-dependent ``a`` is not implemented); when the transition time is unknown (prefer gMAM/sgMAM). |
-| **gMAM** | You want a **time-reparameterization-invariant** minimum action path (no explicit optimization over $T$). | Same as MAM. The dedicated `GeometricGradient` projected-gradient solver now handles state-dependent ``a(x)`` directly: additive noise uses a single tridiagonal solve, diagonal multiplicative noise a per-DOF tridiagonal, and non-diagonal multiplicative noise a sparse block-tridiagonal solve, all with a finite-difference ``\partial_x a`` correction in the descent RHS. | **Non-autonomous** noise; if you need the Onsager-Machlup functional (only FW has a geometric formulation). |
-| **sgMAM** | You want a **Hamiltonian/simple gMAM** formulation that can be efficient in practice. | A [`FreidlinWentzellHamiltonian`](@ref) (formerly `ExtendedPhaseSpace`) with first-order derivatives `H_x`, `H_p`. The convenience constructor on `CoupledSDEs` handles additive, diagonal multiplicative, and general multiplicative noise; the iteration picks the cheapest valid path (shared tridiagonal / per-DOF tridiagonal / sparse block-tridiagonal). | **Non-autonomous** noise; models where the required derivatives of `H` are not available. |
-| **String method** | You want a **minimum energy path / heteroclinic orbit** driven by the deterministic drift (typical use: **gradient** systems). | Deterministic drift field (works for `ContinuousTimeDynamicalSystem`; does not rely on an SDE noise model). | In **non-gradient** systems if you need the *most probable* noise-induced transition path (string gives the deterministic heteroclinic orbit, which generally differs from the instanton). |
+| **MAM** | Fixed transition time $T$ (FW or OM action) | `CoupledSDEs`, autonomous noise; invertible $a$ for additive | $T$ unknown; non-autonomous noise; OM with multiplicative noise |
+| **gMAM** | $T$ unknown; want reparameterization-invariant path | `CoupledSDEs`, autonomous noise | Non-autonomous noise; need OM functional |
+| **sgMAM** | Hamiltonian formulation, often fastest | [`FreidlinWentzellHamiltonian`](@ref) (auto-built from `CoupledSDEs`) | Non-autonomous noise |
+| **String method** | Heteroclinic orbit in gradient systems | Deterministic drift only (any `ContinuousTimeDynamicalSystem`) | Non-gradient system and you want the most probable noise-induced path (string gives the deterministic heteroclinic, not the instanton) |
 
 #### Variants and extensions
 The literature contains a number of extensions of MAM-type methods that may be relevant depending on the model class and numerical difficulties. These variants are not currently implemented in `CriticalTransitions.jl`, but serve as useful pointers:
@@ -79,7 +79,6 @@ The literature contains a number of extensions of MAM-type methods that may be r
 - **tMAM / optimal linear time scaling**: avoids explicit optimization over the transition time by introducing an optimal linear time scaling; can be combined with adaptivity in time discretization [wan_tmam_2015](@citet).
 - **Adaptive MAM**: uses a moving-mesh strategy to concentrate grid points in dynamically important portions of the path, improving efficiency and robustness [zhou_adaptive_mam_2008](@citet).
 - **Non-Gaussian (jump / Lévy) noise**: for systems driven by jump noise, the rate function and path optimization problem differ from the Freidlin--Wentzell diffusive setting; see e.g. an optimal-control-based approach in [wei_most_likely_jumps_2023](@citet).
-- **Multiplicative / state-dependent noise**: following [grafke_long_2017](@citet) (Section 3.5), the geometric / simple-geometric solvers now handle general invertible state-dependent ``a(x)``. [`fw_action`](@ref), [`geometric_action`](@ref), [`minimize_action`](@ref), [`minimize_geometric_action`](@ref) (both the `GeometricGradient` and Optimization.jl paths), and [`minimize_simple_geometric_action`](@ref) automatically use the diffusion tensor ``a(x) = \sigma(x)\sigma(x)^\top`` from the `CoupledSDEs` when the noise is non-additive, with a finite-difference ``\partial_x a`` correction in the descent RHS where required.
 
 ### Minimum action method (MAM)
 Minimization of the specified action functional using the optimization algorithm of `Optimization.jl`. See also [e_minimum_2004](@citet).
@@ -101,8 +100,7 @@ The simple gMAM reduces the complexity of the original gMAM by requiring only fi
 
 The implementation performs a constrained gradient descent for an autonomous system. The
 Hamiltonian ``H(x,p) = \langle b(x), p\rangle + \tfrac{1}{2}\langle p, a(x)\, p\rangle``
-is stored in a [`FreidlinWentzellHamiltonian`](@ref) (the type formerly known as
-`ExtendedPhaseSpace`, which remains available as a deprecated alias). The iteration
+is stored in a [`FreidlinWentzellHamiltonian`](@ref). The iteration
 auto-dispatches on the structure of ``a(x)``:
 
 * additive (`a ≡ I`): one tridiagonal solve shared across degrees of freedom;

--- a/examples/backtracking_KPO.jl
+++ b/examples/backtracking_KPO.jl
@@ -42,7 +42,7 @@ function H_p(x, p)
     return Matrix([H_pu H_pv]')
 end
 
-sys = ExtendedPhaseSpace{false, 2}(H_x, H_p)
+sys = FreidlinWentzellHamiltonian{false, 2}(H_x, H_p)
 
 # Initial path — a smooth "wiggle" connecting two symmetric attractors:
 

--- a/examples/sgMAM_KPO.jl
+++ b/examples/sgMAM_KPO.jl
@@ -54,9 +54,9 @@ function H_p(x, p) # ℜ² → ℜ²
     return Matrix([H_pu H_pv]')
 end
 
-sys = ExtendedPhaseSpace{false, 2}(H_x, H_p)
+sys = FreidlinWentzellHamiltonian{false, 2}(H_x, H_p)
 
-# We saved this function in the `ExtendedPhaseSpace` struct. We want to find the optimal path between two attractors in the phase space. We define the initial trajectory as `wiggle` between the two attractors.
+# We saved this function in the `FreidlinWentzellHamiltonian` struct. We want to find the optimal path between two attractors in the phase space. We define the initial trajectory as `wiggle` between the two attractors.
 
 Nt = 500  # number of discrete time steps
 s = collect(range(0; stop = 1, length = Nt))

--- a/src/CriticalTransitions.jl
+++ b/src/CriticalTransitions.jl
@@ -42,6 +42,7 @@ using Interpolations: linear_interpolation
 using Optimization: Optimization
 using OptimizationOptimisers: Optimisers
 using LinearSolve: LinearProblem, LUFactorization, init, solve, solve!
+using SparseArrays: SparseArrays, sparse, spzeros
 
 # io and documentation
 using Format: Format
@@ -90,7 +91,7 @@ export CoupledSDEs, CoupledODEs, noise_process, covariance_matrix, diffusion_mat
 export drift, div_drift, solver
 export StateSpaceSet
 
-export minimize_simple_geometric_action, ExtendedPhaseSpace
+export minimize_simple_geometric_action, FreidlinWentzellHamiltonian, ExtendedPhaseSpace
 export fw_action, om_action, action, geometric_action
 export minimize_action, action_minimizer, minimize_geometric_action, string_method
 export MinimumActionPath

--- a/src/CriticalTransitions.jl
+++ b/src/CriticalTransitions.jl
@@ -42,7 +42,7 @@ using Interpolations: linear_interpolation
 using Optimization: Optimization
 using OptimizationOptimisers: Optimisers
 using LinearSolve: LinearProblem, LUFactorization, init, solve, solve!
-using SparseArrays: SparseArrays, sparse, spzeros
+using SparseArrays: SparseArrays, sparse
 
 # io and documentation
 using Format: Format

--- a/src/largedeviations/action.jl
+++ b/src/largedeviations/action.jl
@@ -1,30 +1,31 @@
 """
 $(TYPEDSIGNATURES)
 
-Calculates the Freidlin-Wentzell action of a given `path` with time points `time` in a
-drift field specified by the deterministic dynamics `f = dynamic_rule(sys)` and
-(normalized) noise covariance matrix `covariance_matrix(sys)`.
+Calculates the Freidlin-Wentzell action of a given `path` with time points `time` in
+the drift field `f = dynamic_rule(sys)` and (normalized) diffusion tensor of `sys`.
 
-The path must be a `(D x N)` matrix, where `D` is the dimensionality of the system `sys` and
-`N` is the number of path points. The `time` array must have length `N`.
+The path must be a `(D × N)` matrix where `D` is the dimensionality of `sys` and `N`
+is the number of path points. `time` must have length `N`.
 
-Returns a single number, which is the value of the action functional
+Returns a single number, the value of the action functional
 
-``S_T[\\phi_t] = \\frac{1}{2} \\int_0^T || \\dot \\phi_t - f(\\phi_t) ||^2_Q \\text{d}t``
+``S_T[\\phi_t] = \\frac{1}{2} \\int_0^T \\lVert \\dot \\phi_t - f(\\phi_t) \\rVert
+    ^2_{a(\\phi_t)^{-1}} \\, \\mathrm{d}t``
 
-where ``\\phi_t`` denotes the path in state space, ``b`` the drift field, and ``T`` the
-total time of the path. The subscript ``Q`` refers to the
-generalized norm ``||a||_Q^2 := \\langle a, Q^{-1} b \\rangle`` (see `anorm`). Here
-``Q`` is the noise covariance matrix normalized by ``D/L_1(Q)``, with ``L_1`` being the
-L1 matrix norm.
+where ``a(x) = \\sigma(x)\\sigma(x)^\\top`` is the diffusion tensor and the subscript
+``a^{-1}`` denotes the generalized norm
+``\\lVert v\\rVert^2_{a^{-1}} := \\langle v,\\, a^{-1} v\\rangle`` (see [`anorm`](@ref)).
+
+This is the Freidlin-Wentzell **rate function**: it is invariant under uniform rescaling
+of the noise. The diffusion is normalized by a single scale extracted from `sys`,
+matching the long-standing CT convention; see the Large Deviations manual page for
+details.
 """
 function fw_action(sys::CoupledSDEs, path, time)
     @assert all(diff(time) .≈ diff(time[1:2])) "Freidlin-Wentzell action is only defined for equispaced time"
-    # Inverse of covariance matrix
-    A = inv(normalize_covariance!(covariance_matrix(sys)))
-
-    # Compute action integral
-    integrand = fw_integrand(sys, path, time, A)
+    proper_MAM_system(sys)
+    A_at = _inv_covariance_at(sys)
+    integrand = fw_integrand(sys, path, time, A_at)
 
     S = 0
     for i in 1:(size(path, 2) - 1)
@@ -36,27 +37,28 @@ end;
 """
     om_action(sys::CoupledSDEs, path, time, noise_strength)
 
-Calculates the Onsager-Machlup action of a given `path` with time points `time` for the drift field `f = dynamic_rule(sys)` at given `noise_strength`.
+Calculates the Onsager-Machlup action of a given `path` with time points `time` for the
+drift `f = dynamic_rule(sys)` at given `noise_strength` ``\\sigma``.
 
-The path must be a `(D x N)` matrix, where `D` is the dimensionality of the system `sys` and
-`N` is the number of path points. The `time` array must have length `N`.
+Returns a single number,
 
-Returns a single number, which is the value of the action functional
+``S^{\\sigma}_T[\\phi_t] = \\frac{1}{2} \\int_0^T \\left( \\lVert \\dot \\phi_t -
+    f(\\phi_t) \\rVert^2_{a^{-1}} + \\sigma^2 \\nabla \\cdot f \\right) \\, \\mathrm{d}t``
 
-``S^{\\sigma}_T[\\phi_t] = \\frac{1}{2} \\int_0^T \\left( || \\dot \\phi_t - f(\\phi_t) ||^2_Q +
-\\sigma^2 \\nabla \\cdot f \\right) \\, \\text{d} t``
-
-where ``\\phi_t`` denotes the path in state space, ``b`` the drift field, ``T`` the total
-time of the path, and ``\\sigma`` the noise strength. The subscript ``Q`` refers to the
-generalized norm ``||a||_Q^2 := \\langle a, Q^{-1} b \\rangle`` (see `anorm`). Here
-``Q`` is the noise covariance matrix normalized by ``D/L_1(Q)``, with ``L_1`` being the
-L1 matrix norm.
+The ``\\sigma^2 \\nabla\\cdot f`` divergence correction assumes ``a`` is **constant**,
+i.e. additive noise. Multiplicative noise is rejected with an `ArgumentError`; for
+state-dependent ``a(x)`` use [`fw_action`](@ref) (which has no divergence correction).
 """
 function om_action(sys::CoupledSDEs, path, time, noise_strength)
     @assert all(diff(time) .≈ diff(time[1:2])) "Onsager-Machlup action is only defined for equispaced time"
+    sys.noise_type[:additive] || throw(
+        ArgumentError(
+            "om_action is only defined for additive noise: the σ²∇·f divergence " *
+                "correction is invalid when a(x) is state-dependent. Use fw_action instead.",
+        ),
+    )
 
     σ = noise_strength
-    # Compute action integral
     S = 0.0
     for i in 1:(size(path, 2) - 1)
         S +=
@@ -90,61 +92,89 @@ end;
 """
 $(TYPEDSIGNATURES)
 
-Calculates the geometric action of a given `path` with specified `arclength` for the drift
-field specified by the deterministic dynamics `f = dynamic_rule(sys)` and
-(normalized) noise covariance matrix `covariance_matrix(sys)`.
+Calculates the geometric Freidlin-Wentzell action of a given `path` with specified
+`arclength` for the drift `f = dynamic_rule(sys)` and (normalized) diffusion tensor of
+`sys`.
 
-For a given path ``\\varphi``, the geometric action ``\\bar S`` corresponds to the minimum
-of the Freidlin-Wentzell action ``S_T(\\varphi)`` over all travel times ``T>0``, where ``\\varphi``
-denotes the path's parameterization in physical time (see [`fw_action`](@ref)). It is given
-by the integral
+For a given path ``\\varphi``, the geometric action ``\\bar S`` corresponds to the
+minimum of the Freidlin-Wentzell action ``S_T(\\varphi)`` over all travel times
+``T > 0`` (see [`fw_action`](@ref)). It is given by
 
-``\\bar S[\\varphi] = \\int_0^L \\left( ||\\varphi'||_Q \\, ||f(\\varphi)||_Q - \\langle \\varphi', \\,
-    f(\\varphi) \\rangle_Q \\right) \\, \\text{d}s``
+``\\bar S[\\varphi] = \\int_0^L \\left( \\lVert\\varphi'\\rVert_{a^{-1}}\\,
+    \\lVert f(\\varphi)\\rVert_{a^{-1}} - \\langle \\varphi',\\, f(\\varphi)\\rangle_{a^{-1}}
+    \\right) \\, \\mathrm{d}s``
 
-where ``s`` is the arclength coordinate, ``L`` the arclength, ``f`` the drift field, and the
-subscript ``Q`` refers to the generalized dot product ``\\langle a, b \\rangle_Q := a^{\\top}
-\\cdot Q^{-1} b`` (see `anorm`). Here
-``Q`` is the noise covariance matrix normalized by ``D/L_1(Q)``, with ``L_1`` being the
-L1 matrix norm.
-
-Returns the value of the geometric action ``\\bar S``.
+where ``s`` is the arclength coordinate, ``L`` the arclength, and the subscript
+``a^{-1}`` denotes the generalized norm/inner product (see [`anorm`](@ref)). The same
+noise normalization convention as [`fw_action`](@ref) applies.
 """
 function geometric_action(sys::CoupledSDEs, path, arclength = 1.0)
-    A = inv(normalize_covariance!(covariance_matrix(sys)))
+    proper_MAM_system(sys)
+    A_at = _inv_covariance_at(sys)
     b(x) = drift(sys, x)
-    return _geometric_action_from_drift(b, path, arclength, A)
+    return _geometric_action_from_drift(b, path, arclength, A_at)
 end
 
 """
     geometric_action(b::Function, path, arclength=1.0; A=nothing)
 
-Geometric Freidlin-Wentzell action for a drift field `b` and a discrete `path`.
+Geometric Freidlin-Wentzell action for a drift field `b` and a discrete `path`. The
+metric argument `A` selects how the inverse covariance is evaluated at each point:
 
-This is a drift-only convenience overload that uses the same integrand as
-`geometric_action(sys::CoupledSDEs, ...)`, but requires an explicit inverse covariance
-(`A = Q^{-1}`) if you want anything other than the identity metric.
-
-If `A === nothing`, it defaults to the identity metric.
+* `A = nothing` (default): identity inverse covariance everywhere.
+* `A::AbstractMatrix`: constant inverse covariance ``a^{-1}``, used at every path point.
+* `A::Function`: callable returning ``a(x)`` (the uninverted covariance) at state `x`;
+  inverted internally at each path point.
 
 The `path` must be a `(D × N)` matrix with points in columns.
 """
 function geometric_action(b::Function, path, arclength = 1.0; A = nothing)
-    if A === nothing
+    A_at = if A === nothing
         D = size(path, 1)
-        A = LinearAlgebra.Diagonal(ones(eltype(path), D))
+        Returns(LinearAlgebra.Diagonal(ones(eltype(path), D)))
+    elseif A isa AbstractMatrix
+        Returns(A)
+    else
+        let A = A
+            x -> inv(A(x))
+        end
     end
-    return _geometric_action_from_drift(b, path, arclength, A)
+    return _geometric_action_from_drift(b, path, arclength, A_at)
 end
 
-function _geometric_action_from_drift(b::Function, path, arclength::Real, A)
+# Build a callable `x -> a_shape(x)^{-1}` for the given system, where
+# `a_shape(x) = a(x) / s` and `s = L_1(a(x_0))/D` is the noise-magnitude scale extracted
+# at the reference state `x_0 = current_state(sys)`. See the Large Deviations manual page
+# ("Action normalisation") for the rationale.
+function _inv_covariance_at(sys::CoupledSDEs)
+    if sys.noise_type[:additive]
+        a = covariance_matrix(sys)
+        s = LinearAlgebra.norm(a, 1) / size(a, 1)
+        return Returns(s * inv(a))  # = inv(a/s) = a_shape⁻¹
+    end
+    g = diffusion_function(sys)
+    params = current_parameters(sys)
+    σ_ref = g(current_state(sys), params, 0.0)
+    a_ref = σ_ref * σ_ref'
+    s = LinearAlgebra.norm(a_ref, 1) / size(a_ref, 1)
+    return let g = g, params = params, s = s
+        x -> begin
+            σ = g(x, params, 0.0)
+            s * inv(σ * σ')
+        end
+    end
+end
+
+function _geometric_action_from_drift(b::Function, path, arclength::Real, A_at)
     N = size(path, 2)
     v = path_velocity(path, range(0, arclength; length = N); order = 4)
 
     integrand = zeros(eltype(path), N)
     for i in 1:N
-        drift = b(path[:, i])
-        integrand[i] = anorm(v[:, i], A) * anorm(drift, A) - dot(v[:, i], A, drift)
+        xi = view(path, :, i)
+        Ai = A_at(xi)
+        drift_i = b(xi)
+        integrand[i] = anorm(v[:, i], Ai) * anorm(drift_i, Ai) - dot(v[:, i], Ai, drift_i)
     end
 
     S = zero(eltype(path))
@@ -157,17 +187,19 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Computes the squared ``A``-norm ``|| \\dot \\phi_t - b ||^2_A`` (see `fw_action` for
-details). Returns a vector of length `N` containing the values of the above squared norm for each time point in the vector `time`.
+Computes the squared ``a^{-1}``-norm ``\\lVert \\dot \\phi_t - b\\rVert^2_{a(\\phi_t)^{-1}}``
+at each path point (see [`fw_action`](@ref) for details). `A` may be either a constant
+`AbstractMatrix` (used as the inverse diffusion tensor at every path point) or a callable
+`x -> a(x)^{-1}` for state-dependent diffusion. Returns a vector of length `N`.
 """
 function fw_integrand(sys::CoupledSDEs, path, time, A)
     v = path_velocity(path, time; order = 4)
     sqnorm = zeros(size(path, 2))
-    b(x) = drift(sys, x)
     for i in axes(path, 2)
-        # assumes the drift is time independent
-        drift = b(path[:, i])
-        sqnorm[i] = anorm(v[:, i] - drift, A; square = true)
+        xi = view(path, :, i)
+        drift_i = drift(sys, xi)
+        Ai = A isa AbstractMatrix ? A : A(xi)
+        sqnorm[i] = anorm(v[:, i] - drift_i, Ai; square = true)
     end
     return sqnorm
 end;

--- a/src/largedeviations/minimize_action.jl
+++ b/src/largedeviations/minimize_action.jl
@@ -109,10 +109,3 @@ function fix_ends(x::Matrix, x_i, x_f)
     m[:, end] = x_f
     return m
 end;
-
-"""
-    action_minimizer(sys::ContinuousTimeDynamicalSystem, x_i, x_f, T::Real; kwargs...)
-
-Alias for [`minimize_action`](@ref).]
-"""
-const action_minimizer = minimize_action

--- a/src/largedeviations/minimize_geometric_action.jl
+++ b/src/largedeviations/minimize_geometric_action.jl
@@ -177,7 +177,7 @@ function geometric_gradient_step(
     return ws.update
 end
 
-struct GeometricGradientWorkspace{Tupdate, Tprime, Tvec, Tmat, Ttmp, Tarc, TA, Tjac}
+struct GeometricGradientWorkspace{Tupdate, Tprime, Tvec, Tmat, Ttmp, Tarc, TA, Tjac, TAF}
     update::Tupdate
     x_prime::Tprime
     lambdas::Tvec
@@ -185,6 +185,8 @@ struct GeometricGradientWorkspace{Tupdate, Tprime, Tvec, Tmat, Ttmp, Tarc, TA, T
     prod1::Tmat
     prod2::Tmat
     drift_cache::Tmat
+    theta_cache::Tmat        # state-dependent: ϑ_i = a^{-1}(x_i)(λ_i φ'_i - b_i)
+    rhs_explicit::Tmat       # state-dependent: per-grid-point explicit RHS contribution
     temp1::Ttmp
     temp2::Ttmp
     alpha_cache::Tvec
@@ -193,28 +195,44 @@ struct GeometricGradientWorkspace{Tupdate, Tprime, Tvec, Tmat, Ttmp, Tarc, TA, T
     du::Tvec
     v::Tvec
     arc::Tarc
-    A::TA
+    A::TA                    # additive: inverse normalized covariance; multiplicative: nothing
     jac::Tjac
+    a_func::TAF              # nothing (additive), or x -> a(x) (Vector for diagonal, Matrix for general)
 end
 
 function geometric_gradient_workspace(sys::ContinuousTimeDynamicalSystem, path)
     N = size(path, 2)
-    A = inv(normalize_covariance!(covariance_matrix(sys)))
+    Nx = size(path, 1)
     params = current_parameters(sys)
     jac_fun = jacobian(sys)
     jac = let jac_fun = jac_fun, params = params
         x -> jac_fun(x, params, 0.0)
     end
 
+    # Convention B (Freidlin-Wentzell rate function): both branches divide the diffusion
+    # tensor by the noise-magnitude scale `s = L_1(a(x_0))/D` extracted at the reference
+    # state. See `_normalized_a_shape_func` in utils.jl.
+    if sys isa CoupledSDEs && !sys.noise_type[:additive]
+        a_func, _ = _normalized_a_shape_func(sys)
+        A = nothing
+    else
+        a = covariance_matrix(sys)
+        s = LinearAlgebra.norm(a, 1) / size(a, 1)
+        A = s * inv(a)
+        a_func = nothing
+    end
+
     update = similar(path)
     x_prime = zeros(size(path))
     lambdas = zeros(N)
     lambdas_prime = zeros(N)
-    prod1 = zeros(size(path, 1), N - 2)
-    prod2 = zeros(size(path, 1), N - 2)
-    drift_cache = zeros(size(path, 1), N - 2)
-    temp1 = zeros(size(path, 1))
-    temp2 = zeros(size(path, 1))
+    prod1 = zeros(Nx, N - 2)
+    prod2 = zeros(Nx, N - 2)
+    drift_cache = zeros(Nx, N - 2)
+    theta_cache = zeros(Nx, N - 2)
+    rhs_explicit = zeros(Nx, N - 2)
+    temp1 = zeros(Nx)
+    temp2 = zeros(Nx)
     alpha_cache = zeros(N)
     dl = zeros(N - 1)
     d = ones(N)
@@ -230,6 +248,8 @@ function geometric_gradient_workspace(sys::ContinuousTimeDynamicalSystem, path)
         prod1,
         prod2,
         drift_cache,
+        theta_cache,
+        rhs_explicit,
         temp1,
         temp2,
         alpha_cache,
@@ -240,6 +260,7 @@ function geometric_gradient_workspace(sys::ContinuousTimeDynamicalSystem, path)
         arc,
         A,
         jac,
+        a_func,
     )
 end
 
@@ -250,35 +271,177 @@ function geometric_gradient_step!(
         stepsize = 0.1,
         diff_order = 4,
     )
+    # Heymann-VandenEijnden gMAM relaxation step. Eq. (19) of Grafke-Schäfer-Vanden-Eijnden
+    # 2017 gives the descent direction
+    #     ∂φ/∂τ = λ² φ'' - λ H_ϑφ φ' + H_ϑϑ H_φ + λ λ' φ'.
+    # For additive a = I, this collapses to -λ(J-Jᵀ)φ' - Jᵀb + λλ'φ' on the RHS and
+    # T = I - ε λ² ∂²_s on the LHS. For state-dependent a(x) we keep the same descent
+    # equation but evaluate H_ϑφ and a·H_φ pointwise with finite-difference ∂_x a.
     N = size(path, 2)
+    Nx = size(path, 1)
     dx = 1.0 / (N - 1)
 
     path_velocity!(ws.x_prime, path, ws.arc; order = diff_order)
 
+    is_state_dep = ws.a_func !== nothing
+
+    # Compute λ_i and (for state-dependent) ϑ_i at each interior grid point.
     @views for i in 2:(N - 1)
-        velocity_norm = anorm(ws.x_prime[:, i], ws.A)
-        if velocity_norm > 1.0e-14
-            ws.drift_cache[:, i - 1] .= drift(sys, path[:, i])
-            ws.lambdas[i] = anorm(ws.drift_cache[:, i - 1], ws.A) / velocity_norm
-            if !isfinite(ws.lambdas[i])
+        ws.drift_cache[:, i - 1] .= drift(sys, path[:, i])
+    end
+
+    if is_state_dep
+        _gmam_state_dep_lambda_theta!(ws, path, N, Nx)
+    else
+        @views for i in 2:(N - 1)
+            velocity_norm = anorm(ws.x_prime[:, i], ws.A)
+            if velocity_norm > 1.0e-14
+                ws.lambdas[i] = anorm(ws.drift_cache[:, i - 1], ws.A) / velocity_norm
+                isfinite(ws.lambdas[i]) || (ws.lambdas[i] = 0.0)
+            else
                 ws.lambdas[i] = 0.0
             end
-        else
-            ws.lambdas[i] = 0.0
         end
     end
+
     @views for i in 2:(N - 1)
         ws.lambdas_prime[i] = (ws.lambdas[i + 1] - ws.lambdas[i - 1]) / (2 * dx)
     end
 
-    @views for i in 2:(N - 1)
-        J = ws.jac(path[:, i])
-        LinearAlgebra.mul!(ws.temp1, J, ws.x_prime[:, i])
-        LinearAlgebra.mul!(ws.temp2, J', ws.x_prime[:, i])
-        ws.prod1[:, i - 1] .= ws.temp1 .- ws.temp2
-        LinearAlgebra.mul!(ws.prod2[:, i - 1], J', ws.drift_cache[:, i - 1])
+    # Build explicit RHS contribution (everything except the implicit λ² φ'' term).
+    if is_state_dep
+        _gmam_state_dep_rhs!(ws, path, N, Nx)
+    else
+        @views for i in 2:(N - 1)
+            J = ws.jac(path[:, i])
+            LinearAlgebra.mul!(ws.temp1, J, ws.x_prime[:, i])
+            LinearAlgebra.mul!(ws.temp2, J', ws.x_prime[:, i])
+            ws.prod1[:, i - 1] .= ws.temp1 .- ws.temp2
+            LinearAlgebra.mul!(ws.prod2[:, i - 1], J', ws.drift_cache[:, i - 1])
+        end
     end
 
+    # Implicit step. Per Heymann-Vanden-Eijnden 2008 eq. (3.6) and Grafke et al. 2017
+    # eq. (19), the gMAM descent contains the term λ² φ'' (no a^{-1} factor), so the
+    # implicit operator (1 - h λ² ∂_s²) is **shared across DOFs** regardless of whether
+    # a(x) is state-dependent. State-dependence enters only through the explicit RHS
+    # built above. (Contrast sgMAM eq. (43), where the implicit operator is
+    # (1 - h μ^{-2} H_ϑϑ^{-1} ∂_s²) and does carry a^{-1}.)
+    _gmam_implicit_shared!(ws, path, N, stepsize, dx, is_state_dep)
+
+    return ws.update
+end
+
+# ----- state-dependent: λ_i and ϑ_i = a^{-1}(λ φ' - b) per interior grid point -----
+function _gmam_state_dep_lambda_theta!(ws, path, N, Nx)
+    for i in 2:(N - 1)
+        a_i = ws.a_func(view(path, :, i))
+        b_i = view(ws.drift_cache, :, i - 1)
+        φp = view(ws.x_prime, :, i)
+        if _is_diagonal_a(a_i)
+            a_vec = _diag_view(a_i)
+            num = sum(b_i .^ 2 ./ a_vec)
+            den = sum(φp .^ 2 ./ a_vec)
+            λ = den > 1.0e-28 ? sqrt(num / den) : 0.0
+            isfinite(λ) || (λ = 0.0)
+            ws.lambdas[i] = λ
+            @inbounds for k in 1:Nx
+                ws.theta_cache[k, i - 1] = (λ * φp[k] - b_i[k]) / a_vec[k]
+            end
+        else
+            A_inv_b = a_i \ Vector(b_i)
+            A_inv_phi = a_i \ Vector(φp)
+            num = dot(b_i, A_inv_b)
+            den = dot(φp, A_inv_phi)
+            λ = den > 1.0e-28 ? sqrt(num / den) : 0.0
+            isfinite(λ) || (λ = 0.0)
+            ws.lambdas[i] = λ
+            θ = a_i \ (λ .* Vector(φp) .- Vector(b_i))
+            @inbounds for k in 1:Nx
+                ws.theta_cache[k, i - 1] = θ[k]
+            end
+        end
+    end
+    return nothing
+end
+
+# ----- state-dependent: explicit RHS contribution per interior grid point -----
+# For each i, store ws.rhs_explicit[:, i-1] = -λ_i H_ϑφ φ'_i + a(x_i) H_φ_i + λ_i λ'_i φ'_i.
+function _gmam_state_dep_rhs!(ws, path, N, Nx)
+    h = max(sqrt(eps(eltype(path))), 1.0e-8)
+    e = zeros(eltype(path), Nx)
+    Hphi = zeros(eltype(path), Nx)            # H_φ at current grid point
+    Hpphi = zeros(eltype(path), Nx)           # H_ϑφ φ' at current grid point
+    aHphi = zeros(eltype(path), Nx)           # a(x) · H_φ at current grid point
+
+    for i in 2:(N - 1)
+        xi = path[:, i]
+        φp = view(ws.x_prime, :, i)
+        ϑ = view(ws.theta_cache, :, i - 1)
+        J = ws.jac(xi)
+
+        a_i = ws.a_func(xi)
+        is_diag = _is_diagonal_a(a_i)
+
+        fill!(Hphi, 0)
+        fill!(Hpphi, 0)
+        # (J φ') and (J^T ϑ) contributions (always present)
+        LinearAlgebra.mul!(Hpphi, J, φp)                  # (J φ')_j
+        LinearAlgebra.mul!(Hphi, J', ϑ)                   # (J^T ϑ)_l
+
+        # ∂_x a contributions via central finite differences. For each direction l in 1..Nx,
+        # compute ∂_l a; accumulate (1/2) ⟨ϑ, ∂_l a ϑ⟩ into H_φ_l and (∂_l a · ϑ) φ'_l into
+        # (H_ϑφ φ').
+        @inbounds for l in 1:Nx
+            fill!(e, 0)
+            e[l] = h
+            ap = ws.a_func(xi .+ e)
+            am = ws.a_func(xi .- e)
+            if is_diag
+                # ap, am are diagonal: ∂_l a_k = (ap[k] - am[k])/(2h)
+                ap_v = _diag_view(ap)
+                am_v = _diag_view(am)
+                @inbounds for k in 1:Nx
+                    dla = (ap_v[k] - am_v[k]) / (2 * h)
+                    Hphi[l] += 0.5 * dla * ϑ[k]^2
+                    Hpphi[k] += dla * ϑ[k] * φp[l]
+                end
+            else
+                # ap, am are full Matrices; ∂_l a is a D×D matrix
+                @inbounds for k1 in 1:Nx, k2 in 1:Nx
+                    dla = (ap[k1, k2] - am[k1, k2]) / (2 * h)
+                    Hphi[l] += 0.5 * dla * ϑ[k1] * ϑ[k2]
+                    Hpphi[k1] += dla * ϑ[k2] * φp[l]
+                end
+            end
+        end
+
+        # a(x_i) · H_φ
+        if is_diag
+            a_vec = _diag_view(a_i)
+            @inbounds for k in 1:Nx
+                aHphi[k] = a_vec[k] * Hphi[k]
+            end
+        else
+            LinearAlgebra.mul!(aHphi, a_i, Hphi)
+        end
+
+        # RHS at point i: -λ H_ϑφ φ' + a H_φ + λ λ' φ'
+        λ = ws.lambdas[i]
+        λp = ws.lambdas_prime[i]
+        @inbounds for k in 1:Nx
+            ws.rhs_explicit[k, i - 1] = -λ * Hpphi[k] + aHphi[k] + λ * λp * φp[k]
+        end
+    end
+    return nothing
+end
+
+# ----- implicit step: (1 - h λ² ∂_s²) — shared tridiagonal across DOFs (eq. 19 gMAM) -----
+# Whether a(x) is additive or state-dependent, the gMAM implicit operator is independent
+# of a; state dependence enters only through the explicit RHS (precomputed above). The
+# additive branch keeps the fast (J - Jᵀ)φ' / Jᵀb decomposition; the state-dependent
+# branch uses the precomputed `rhs_explicit` matrix.
+function _gmam_implicit_shared!(ws, path, N, stepsize, dx, is_state_dep)
     ws.d .= 1
     ws.dl .= 0
     ws.du .= 0
@@ -310,17 +473,18 @@ function geometric_gradient_step!(
                 rhs[i] = path[j, i]
                 continue
             end
-            rhs_val =
-                path[j, i] +
-                stepsize * (
-                -ws.lambdas[i] * ws.prod1[j, i - 1] - ws.prod2[j, i - 1] +
-                    ws.lambdas[i] * ws.lambdas_prime[i] * ws.x_prime[j, i]
-            )
+            rhs_val = if is_state_dep
+                path[j, i] + stepsize * ws.rhs_explicit[j, i - 1]
+            else
+                path[j, i] + stepsize * (
+                    -ws.lambdas[i] * ws.prod1[j, i - 1] - ws.prod2[j, i - 1] +
+                        ws.lambdas[i] * ws.lambdas_prime[i] * ws.x_prime[j, i]
+                )
+            end
             rhs[i] = isfinite(rhs_val) ? rhs_val : path[j, i]
         end
         solve!(cache)
         ws.update[j, :] .= cache.u
     end
-
-    return ws.update
+    return nothing
 end

--- a/src/largedeviations/sgMAM.jl
+++ b/src/largedeviations/sgMAM.jl
@@ -1,62 +1,142 @@
 """
-A structure representing a extanded phase space system where your dissipative vector field is embedded in a doubled dimensional phase space. Given old phase space coordinates `x` of a vector field `f(x)`, we can define the canonical momenta `p`, such that the new phase space coordinates are `(x, p)`. The dynamics in this extended phase space are then governed by the Hamtiltonian system:
+    FreidlinWentzellHamiltonian{IIP, D, Hx, Hp, AF}
 
-``H = p^2 + x \\dot f(x)``
+A discretized representation of the Freidlin-Wentzell Hamiltonian associated with an SDE
+``dX = b(X)\\, dt + \\sqrt{\\varepsilon}\\, \\sigma(X)\\, dW``. The Hamiltonian is
 
-Hence, this system operates in an extended phase space where the Hamiltonian is assumed to be quadratic in the extended momentum.
+```math
+H(x, p) = \\langle b(x),\\, p \\rangle + \\tfrac{1}{2} \\langle p,\\, a(x)\\, p \\rangle,
+```
 
-The struct `ExtendedPhaseSpace` holds the Hamilton's functions `H_x` and `H_p`.
+where ``a(x) = \\sigma(x) \\sigma(x)^\\top``. The struct stores the partial derivatives
+``H_x`` and ``H_p`` of the Hamiltonian and, for state-dependent noise, an optional
+callable `a_func(x)` returning the diffusion tensor ``a(x)``. The iteration dispatches
+on the return type of `a_func`:
+
+* `a_func === nothing` → additive noise ``a \\equiv I``; the implicit step uses a single
+  tridiagonal solve shared across all degrees of freedom (cheapest case).
+* `a_func(x)::AbstractVector` → *diagonal* state-dependent ``a(x)``; the implicit step
+  decouples and uses a tridiagonal solve **per** degree of freedom.
+* `a_func(x)::AbstractMatrix` → *general* invertible ``a(x)``; the implicit step solves a
+  sparse block-tridiagonal system of size ``(N-2)D \\times (N-2)D``.
+
+Construct via:
+
+* `FreidlinWentzellHamiltonian(ds)` for a `CoupledSDEs` / `CoupledODEs`. For
+  multiplicative noise the constructor auto-selects the diagonal or general
+  representation based on whether ``\\sigma(x)\\sigma(x)^\\top`` is diagonal at the
+  initial state, and adds the state-dependent ``\\frac{1}{2} p^\\top (\\partial_x a) p``
+  term to ``H_x`` via finite differences on ``a``.
+* `FreidlinWentzellHamiltonian{IIP, D}(H_x, H_p; a_func = nothing)` for a hand-rolled
+  Hamiltonian; the user-supplied `H_x` must already include the
+  ``\\frac{1}{2} p^\\top (\\partial_x a) p`` term when `a_func` is state-dependent.
+
+!!! note "Deprecated alias"
+    `ExtendedPhaseSpace` is retained as a deprecated alias for backwards compatibility.
 """
-struct ExtendedPhaseSpace{IIP, D, Hx, Hp}
+struct FreidlinWentzellHamiltonian{IIP, D, Hx, Hp, AF}
     H_x::Hx
     H_p::Hp
+    a_func::AF
+    noise_shape::Symbol
 
-    function ExtendedPhaseSpace(ds::ContinuousTimeDynamicalSystem)
+    function FreidlinWentzellHamiltonian(ds::ContinuousTimeDynamicalSystem)
         if ds isa CoupledSDEs
-            proper_sgMAM_system(ds)
+            proper_MAM_system(ds)
         end
 
         f = dynamic_rule(ds)
         jac = jacobian(ds)
         param = current_parameters(ds)
 
-        function H_x(x, p) # ℜ² → ℜ²
-            Hx = similar(x)
+        a_func, noise_shape = if ds isa CoupledSDEs
+            _normalized_a_shape_func(ds)
+        else
+            nothing, :additive
+        end
 
+        function H_x(x, p)
+            Hx = similar(x)
             for idx in 1:size(x, 2)
-                jax = jac(x[:, idx], param, 0.0)
-                for idc in 1:size(x, 1)
-                    Hx[idc, idx] = dot(jax[:, idc], p[:, idx])
+                xi = x[:, idx]
+                pi = p[:, idx]
+                jax = jac(xi, param, 0.0)
+                @inbounds for idc in 1:size(x, 1)
+                    Hx[idc, idx] = dot(jax[:, idc], pi)
+                end
+                if a_func !== nothing
+                    Dn = size(x, 1)
+                    h = max(sqrt(eps(eltype(xi))), 1.0e-8)
+                    sample = a_func(xi)
+                    is_diag = _is_diagonal_a(sample)
+                    # Single preallocated unit-vector buffer reused across all j.
+                    e = zeros(eltype(xi), Dn)
+                    for j in 1:Dn
+                        fill!(e, 0)
+                        e[j] = h
+                        ap = a_func(xi .+ e)
+                        am = a_func(xi .- e)
+                        if is_diag
+                            # diagonal: ∂a_k/∂x_j; H_x_j += (1/2) Σ_k p_k² ∂a_k/∂x_j
+                            dla = (_diag_view(ap) .- _diag_view(am)) ./ (2 * h)
+                            Hx[j, idx] += 0.5 * dot(pi .^ 2, dla)
+                        else
+                            # general: ∂a_{kl}/∂x_j; H_x_j += (1/2) p^T (∂a/∂x_j) p
+                            Hx[j, idx] += 0.5 * dot(pi, (ap .- am) ./ (2 * h), pi)
+                        end
+                    end
                 end
             end
             return Hx
         end
-        function H_p(x, p) # ℜ² → ℜ²
+        function H_p(x, p)
             Hp = similar(x)
-
             for idx in 1:size(x, 2)
-                Hp[:, idx] = p[:, idx] + f(x[:, idx], param, 0.0)
+                xi = x[:, idx]
+                pi = p[:, idx]
+                b = f(xi, param, 0.0)
+                if a_func === nothing
+                    Hp[:, idx] = pi .+ b
+                else
+                    a_i = a_func(xi)
+                    if _is_diagonal_a(a_i)
+                        Hp[:, idx] = b .+ _diag_view(a_i) .* pi
+                    else
+                        Hp[:, idx] = b .+ a_i * pi
+                    end
+                end
             end
             return Hp
         end
-        return new{isinplace(ds), dimension(ds), typeof(H_x), typeof(H_p)}(H_x, H_p)
+        return new{
+            isinplace(ds), dimension(ds), typeof(H_x), typeof(H_p), typeof(a_func),
+        }(H_x, H_p, a_func, noise_shape)
     end
-    function ExtendedPhaseSpace{IIP, D}(H_x::Function, H_p::Function) where {IIP, D}
-        return new{IIP, D, typeof(H_x), typeof(H_p)}(H_x, H_p)
+    function FreidlinWentzellHamiltonian{IIP, D}(
+            H_x::Function, H_p::Function; a_func = nothing,
+        ) where {IIP, D}
+        noise_shape = a_func === nothing ? :additive : :general
+        return new{IIP, D, typeof(H_x), typeof(H_p), typeof(a_func)}(
+            H_x, H_p, a_func, noise_shape,
+        )
     end
 end
 
-function prettyprint(mlp::ExtendedPhaseSpace{IIP, D}) where {IIP, D}
-    return "Doubled $D-dimensional phase space containing $(IIP ? "in-place" : "out-of-place") functions"
+Base.@deprecate_binding ExtendedPhaseSpace FreidlinWentzellHamiltonian
+
+function prettyprint(mlp::FreidlinWentzellHamiltonian{IIP, D}) where {IIP, D}
+    noise = mlp.noise_shape == :additive ? "additive" :
+        mlp.noise_shape == :diagonal ? "diagonal multiplicative" :
+        "general multiplicative"
+    return "Freidlin-Wentzell Hamiltonian on $D-dimensional state space ($noise noise), containing $(IIP ? "in-place" : "out-of-place") H_x and H_p"
 end
 
-Base.show(io::IO, mlp::ExtendedPhaseSpace) = print(io, prettyprint(mlp))
+Base.show(io::IO, mlp::FreidlinWentzellHamiltonian) = print(io, prettyprint(mlp))
 
 """
 $(TYPEDSIGNATURES)
 
 Performs the simplified geometric Minimal Action Method (sgMAM) on the given system `sys`.
-Our implementation is only valid for additive noise.
 
 This method computes the optimal path in the phase space of a Hamiltonian system that
 minimizes the Freidlin–Wentzell action. The Hamiltonian functions `H_x` and `H_p` define
@@ -90,7 +170,7 @@ sacrificing accuracy.
   - `reltol::Real=NaN`: relative tolerance for early stopping based on action change
 """
 function minimize_simple_geometric_action(
-        sys::ExtendedPhaseSpace,
+        sys::FreidlinWentzellHamiltonian,
         x_initial::Matrix{T},
         optimizer::GeometricGradient = GeometricGradient(; stepsize = 1.0e3);
         maxiters::Int = 1000,
@@ -99,30 +179,31 @@ function minimize_simple_geometric_action(
         abstol::Real = NaN,
         reltol::Real = NaN,
     ) where {T}
-    H_p, H_x = sys.H_p, sys.H_x
+    H_p, H_x, a_func = sys.H_p, sys.H_x, sys.a_func
 
     Nx, Nt = size(x_initial)
     s = range(0; stop = 1, length = Nt)
     x, p, pdot, xdot, lambda, alpha = init_allocation(x_initial, Nt)
     xdotdot = zeros(size(xdot))
+    p_zero = zero(xdot)
 
     x_prev = similar(x)
 
     # Ensure a consistent starting path for action comparisons
     interpolate_path!(x, alpha, s)
-    _sgmam_refresh!(xdot, p, lambda, x, H_p)
+    _sgmam_refresh!(xdot, p, lambda, x, H_p, a_func, p_zero)
     initial_action = FW_action(xdot, p)
 
     function try_step!(ϵ)
-        update!(x, xdot, xdotdot, p, pdot, lambda, H_x, H_p, ϵ)
+        update!(x, xdot, xdotdot, p, pdot, lambda, H_x, H_p, ϵ, a_func)
         interpolate_path!(x, alpha, s)
-        _sgmam_refresh!(xdot, p, lambda, x, H_p)
+        _sgmam_refresh!(xdot, p, lambda, x, H_p, a_func, p_zero)
         return FW_action(xdot, p)
     end
     save!() = copyto!(x_prev, x)
     function restore!()
         copyto!(x, x_prev)
-        return _sgmam_refresh!(xdot, p, lambda, x, H_p)
+        return _sgmam_refresh!(xdot, p, lambda, x, H_p, a_func, p_zero)
     end
 
     current_action, _ = backtracking_optimize!(
@@ -162,7 +243,7 @@ function minimize_simple_geometric_action(
         kwargs...,
     )
     return minimize_simple_geometric_action(
-        ExtendedPhaseSpace(sys), Matrix(Matrix(x_initial)'), optimizer; kwargs...
+        FreidlinWentzellHamiltonian(sys), Matrix(Matrix(x_initial)'), optimizer; kwargs...
     )
 end
 
@@ -177,7 +258,7 @@ function init_allocation(x_initial, Nt)
     return x, p, pdot, xdot, lambda, alpha
 end
 
-function update!(x, xdot, xdotdot, p, pdot, lambda, H_x, H_p, ϵ)
+function update!(x, xdot, xdotdot, p, pdot, lambda, H_x, H_p, ϵ, a_func = nothing)
     # xdot, p, and lambda are assumed to be pre-computed and consistent with x
     # (via _sgmam_refresh! or central_diff! + update_p!)
     central_diff!(pdot, p)
@@ -186,24 +267,42 @@ function update!(x, xdot, xdotdot, p, pdot, lambda, H_x, H_p, ϵ)
     # implicit update
     central_diff!(xdotdot, xdot)
 
-    return update_x!(x, lambda, pdot, xdotdot, Hx, ϵ)
+    return update_x!(x, lambda, pdot, xdotdot, Hx, ϵ, a_func; path = x)
 end
 
-function update_x!(x, λ, p′, x′′, Hx, ϵ)
-    # each dof has same lambda, but possibly different H_pp^{-1}
+function update_x!(x, λ, p′, x′′, Hx, ϵ, a_func = nothing; path = x)
+    # Three implicit-step variants, picked by the type of `a_func(x)`:
+    # * a_func === nothing → additive a = I; single tridiagonal shared across DOFs.
+    # * a_func(x) :: AbstractVector → diagonal a(x); per-DOF tridiagonal with coefficient
+    #   λ_i² / a_kk(x_i). DOFs decouple in the implicit step.
+    # * a_func(x) :: AbstractMatrix → general invertible a(x); the equation
+    #   x_new[:, i] - ϵ λ_i² a^{-1}(x_i) (x_new[:, i+1] - 2 x_new[:, i] + x_new[:, i-1]) = R_i
+    #   is multiplied by a(x_i) to avoid matrix inverses, giving a sparse block-tridiagonal
+    #   system with diagonal blocks (a(x_i) + 2ϵλ_i² I) and off-diagonal blocks (-ϵλ_i² I).
     Nx, Nt = size(x)
     xa = x[:, 1]
     xb = x[:, end]
-
     idxc = 2:(Nt - 1)
 
-    # Tridiagonal system is shared across dof
+    if a_func === nothing
+        _update_x_additive!(x, λ, p′, x′′, Hx, ϵ, xa, xb, idxc, Nx, Nt)
+    else
+        sample = a_func(view(path, :, 2))
+        if _is_diagonal_a(sample)
+            _update_x_diag!(x, λ, p′, x′′, Hx, ϵ, xa, xb, idxc, Nx, Nt, a_func)
+        else
+            _update_x_general!(x, λ, p′, x′′, Hx, ϵ, xa, xb, idxc, Nx, Nt, a_func)
+        end
+    end
+    return nothing
+end
+
+function _update_x_additive!(x, λ, p′, x′′, Hx, ϵ, xa, xb, idxc, Nx, Nt)
     d = 1 .+ 2 .* ϵ .* λ[2:(end - 1)] .^ 2
     du = -ϵ .* λ[2:(end - 2)] .^ 2
     dl = -ϵ .* λ[3:(end - 1)] .^ 2
     T = LinearAlgebra.Tridiagonal(dl, d, du)
 
-    # One cache per thread (solve! is not thread-safe on a shared cache)
     nthreads = Threads.nthreads()
     if hasmethod(Threads.nthreads, Tuple{Symbol})
         nthreads = Threads.nthreads(:default) + Threads.nthreads(:interactive)
@@ -221,28 +320,162 @@ function update_x!(x, λ, p′, x′′, Hx, ϵ)
     Threads.@threads for dof in 1:Nx
         cache = caches[Threads.threadid()]
         rhs = cache.b
-
         @inbounds for k in 1:length(rhs)
             i = k + 1
             rhs[k] = x[dof, i] + ϵ * (λ[i] * p′[dof, i] + Hx[dof, i] - λ[i]^2 * x′′[dof, i])
         end
         rhs[1] += ϵ * λ[2]^2 * xa[dof]
         rhs[end] += ϵ * λ[end - 1]^2 * xb[dof]
-
         solve!(cache)
         x[dof, idxc] .= cache.u
     end
     return nothing
 end
 
-function update_p!(p, lambda, x, xdot, H_p)
-    # Alternative: Direct computation, only correct for quadratic Hamiltonian in p,
-    # where H_pp does not depend on p
-    b_ = H_p(x, 0 * x)
-    lambda .= sqrt.(sum(b_ .^ 2; dims = 1) ./ sum(xdot .^ 2; dims = 1))
-    lambda[1] = 0
-    lambda[end] = 0
-    p .= (lambda .* xdot .- b_)
+function _update_x_diag!(x, λ, p′, x′′, Hx, ϵ, xa, xb, idxc, Nx, Nt, a_func)
+    a_at = Matrix{eltype(x)}(undef, Nx, Nt)
+    for i in 1:Nt
+        a_at[:, i] .= _diag_view(a_func(x[:, i]))
+    end
+
+    Threads.@threads for dof in 1:Nx
+        α = [ϵ * λ[i]^2 / a_at[dof, i] for i in 2:(Nt - 1)]
+        d = 1 .+ 2 .* α
+        du = -α[1:(end - 1)]
+        dl = -α[2:end]
+        T_dof = LinearAlgebra.Tridiagonal(dl, d, du)
+        rhs = zeros(eltype(x), length(d))
+        @inbounds for k in 1:length(rhs)
+            i = k + 1
+            rhs[k] = x[dof, i] + ϵ * (
+                λ[i] * p′[dof, i] + Hx[dof, i] - (λ[i]^2 / a_at[dof, i]) * x′′[dof, i]
+            )
+        end
+        rhs[1] += α[1] * xa[dof]
+        rhs[end] += α[end] * xb[dof]
+        x[dof, idxc] .= T_dof \ rhs
+    end
+    return nothing
+end
+
+function _update_x_general!(x, λ, p′, x′′, Hx, ϵ, xa, xb, idxc, Nx, Nt, a_func)
+    N_in = Nt - 2
+    n = N_in * Nx
+
+    # Precompute a(x_i) at each interior grid point.
+    A_blocks = Vector{Matrix{eltype(x)}}(undef, N_in)
+    for i_in in 1:N_in
+        A_blocks[i_in] = Matrix(a_func(x[:, i_in + 1]))
+    end
+
+    # Build sparse block-tridiagonal: diagonal blocks (a(x_i) + 2ϵλ_i² I),
+    # off-diagonal blocks -ϵ λ_i² I.
+    nnz_est = N_in * Nx * Nx + 2 * (N_in - 1) * Nx
+    Iv = Vector{Int}(undef, 0); sizehint!(Iv, nnz_est)
+    Jv = Vector{Int}(undef, 0); sizehint!(Jv, nnz_est)
+    Vv = Vector{eltype(x)}(undef, 0); sizehint!(Vv, nnz_est)
+    r = zeros(eltype(x), n)
+
+    for i_in in 1:N_in
+        i = i_in + 1
+        base = (i_in - 1) * Nx
+        A_i = A_blocks[i_in]
+        λi2 = λ[i]^2
+        # Diagonal block (a(x_i) + 2 ϵ λ_i² I)
+        for j in 1:Nx, k in 1:Nx
+            v = A_i[j, k] + (j == k ? 2 * ϵ * λi2 : zero(eltype(x)))
+            push!(Iv, base + j); push!(Jv, base + k); push!(Vv, v)
+        end
+        # Off-diagonal block to the left: -ϵ λ_i² I
+        if i_in > 1
+            baseL = (i_in - 2) * Nx
+            for j in 1:Nx
+                push!(Iv, base + j); push!(Jv, baseL + j); push!(Vv, -ϵ * λi2)
+            end
+        end
+        # Off-diagonal block to the right: -ϵ λ_i² I
+        if i_in < N_in
+            baseR = i_in * Nx
+            for j in 1:Nx
+                push!(Iv, base + j); push!(Jv, baseR + j); push!(Vv, -ϵ * λi2)
+            end
+        end
+        # RHS: A_i (x[:, i] + ϵ(λ_i p'_i + Hx_i)) - ϵ λ_i² x''_i + boundary contributions
+        rhs_block = A_i * (x[:, i] .+ ϵ .* (λ[i] .* p′[:, i] .+ Hx[:, i])) .-
+                        ϵ * λi2 .* x′′[:, i]
+        if i_in == 1
+            rhs_block .+= ϵ * λi2 .* xa
+        end
+        if i_in == N_in
+            rhs_block .+= ϵ * λi2 .* xb
+        end
+        @inbounds for j in 1:Nx
+            r[base + j] = rhs_block[j]
+        end
+    end
+
+    M = sparse(Iv, Jv, Vv, n, n)
+    sol = M \ r
+    for i_in in 1:N_in
+        base = (i_in - 1) * Nx
+        @inbounds for j in 1:Nx
+            x[j, i_in + 1] = sol[base + j]
+        end
+    end
+    return nothing
+end
+
+function update_p!(p, lambda, x, xdot, H_p, a_func = nothing, p_zero = zero(x))
+    # Closed-form on the zero-energy shell H(x, p) = 0 (eqs. 40-41 of
+    # Grafke-Schäfer-Vanden-Eijnden 2017):
+    #   λ = |b|_a / |xdot|_a    with ⟨u, v⟩_a := ⟨u, a^{-1} v⟩
+    #   p = a^{-1}(λ xdot - b)
+    fill!(p_zero, 0)
+    b_ = H_p(x, p_zero)
+    Nt = size(x, 2)
+    if a_func === nothing
+        lambda .= sqrt.(sum(b_ .^ 2; dims = 1) ./ sum(xdot .^ 2; dims = 1))
+        lambda[1] = 0
+        lambda[end] = 0
+        p .= (lambda .* xdot .- b_)
+    else
+        # Cache a(x_i) once per grid point to avoid calling `a_func` twice (once for
+        # λ, once for p) — `a_func` is often the expensive part of the iteration.
+        sample = a_func(view(x, :, 1))
+        if _is_diagonal_a(sample)
+            a_cache = Vector{Vector{eltype(x)}}(undef, Nt)
+            @inbounds for i in 1:Nt
+                a_cache[i] = collect(_diag_view(a_func(x[:, i])))
+                a_i = a_cache[i]
+                num = sum(b_[:, i] .^ 2 ./ a_i)
+                den = sum(xdot[:, i] .^ 2 ./ a_i)
+                lambda[1, i] = den > 0 ? sqrt(num / den) : zero(eltype(x))
+            end
+            lambda[1] = 0
+            lambda[end] = 0
+            @inbounds for i in 1:Nt
+                a_i = a_cache[i]
+                p[:, i] .= (lambda[1, i] .* xdot[:, i] .- b_[:, i]) ./ a_i
+            end
+        else
+            a_cache = Vector{typeof(sample)}(undef, Nt)
+            @inbounds for i in 1:Nt
+                a_cache[i] = a_func(x[:, i])
+                A_i = a_cache[i]
+                A_inv_b = A_i \ b_[:, i]
+                A_inv_xdot = A_i \ xdot[:, i]
+                num = dot(b_[:, i], A_inv_b)
+                den = dot(xdot[:, i], A_inv_xdot)
+                lambda[1, i] = den > 0 ? sqrt(num / den) : zero(eltype(x))
+            end
+            lambda[1] = 0
+            lambda[end] = 0
+            @inbounds for i in 1:Nt
+                A_i = a_cache[i]
+                p[:, i] .= A_i \ (lambda[1, i] .* xdot[:, i] .- b_[:, i])
+            end
+        end
+    end
     return nothing
 end
 
@@ -252,20 +485,21 @@ function central_diff!(xdot, x)
     return nothing
 end
 
-function _sgmam_refresh!(xdot, p, lambda, x, H_p)
+function _sgmam_refresh!(xdot, p, lambda, x, H_p, a_func = nothing, p_zero = zero(x))
     central_diff!(xdot, x)
-    update_p!(p, lambda, x, xdot, H_p)
+    update_p!(p, lambda, x, xdot, H_p, a_func, p_zero)
     return nothing
 end
 
-FW_action(xdot, p) = dot(xdot, p) / 2
+"""
+    FW_action(xdot, p)
 
-function proper_sgMAM_system(ds::CoupledSDEs)
-    proper_MAM_system(ds)
-    Σ = covariance_matrix(ds)
-    return LinearAlgebra.isdiag(Σ) || throw(
-        ArgumentError(
-            "Simple geometric action is only defined for diagonal noise. The noise covariance matrix is not diagonal.",
-        ),
-    )
-end
+Trapezoidal quadrature of ``\\int_0^1 \\langle p, \\dot\\varphi \\rangle\\, ds`` on the discretized path
+used by the sgMAM iteration. On the zero-energy shell ``H(\\varphi, p) = 0`` this equals the
+Freidlin-Wentzell action ``(1/2) \\int_0^T \\langle \\dot\\varphi - b,\\, a^{-1}(\\dot\\varphi - b) \\rangle\\, dt``.
+
+`xdot` here is the *unnormalized* central difference `(x[:, i+1] - x[:, i-1]) / 2`
+produced by [`central_diff!`](@ref), which already absorbs the arc-length measure `ds`, so no
+further division is performed.
+"""
+FW_action(xdot, p) = dot(xdot, p)

--- a/src/largedeviations/sgMAM.jl
+++ b/src/largedeviations/sgMAM.jl
@@ -402,7 +402,7 @@ function _update_x_general!(x, λ, p′, x′′, Hx, ϵ, xa, xb, idxc, Nx, Nt, 
         end
         # RHS: A_i (x[:, i] + ϵ(λ_i p'_i + Hx_i)) - ϵ λ_i² x''_i + boundary contributions
         rhs_block = A_i * (x[:, i] .+ ϵ .* (λ[i] .* p′[:, i] .+ Hx[:, i])) .-
-                        ϵ * λi2 .* x′′[:, i]
+            ϵ * λi2 .* x′′[:, i]
         if i_in == 1
             rhs_block .+= ϵ * λi2 .* xa
         end

--- a/src/largedeviations/string_method.jl
+++ b/src/largedeviations/string_method.jl
@@ -28,7 +28,7 @@ action via [`geometric_action`](@ref). For drift-only systems (e.g. `sys::Functi
 same geometric action is computed assuming an identity noise covariance.
 """
 function string_method(
-        sys::Union{ExtendedPhaseSpace, Function},
+        sys::Union{FreidlinWentzellHamiltonian, Function},
         x_initial::Matrix;
         stepsize::Real = 1.0e-1,
         integrator = Euler(),
@@ -56,7 +56,7 @@ function string_method(
     end
 
     path_sss = StateSpaceSet(x')
-    S = if sys isa ExtendedPhaseSpace
+    S = if sys isa FreidlinWentzellHamiltonian
         NaN
     elseif sys isa Function
         geometric_action(sys, x, 1.0)
@@ -108,7 +108,7 @@ function string_method(sys::CoupledSDEs, init; kwargs...)
 end
 
 function string_method(
-        b::Union{ExtendedPhaseSpace, Function},
+        b::Union{FreidlinWentzellHamiltonian, Function},
         x_initial::StateSpaceSet{D};
         stepsize::Real = 1.0e-1,
         integrator = Euler(),
@@ -137,7 +137,7 @@ function string_method(
     end
 
     path_sss = StateSpaceSet(x')
-    S = if b isa ExtendedPhaseSpace
+    S = if b isa FreidlinWentzellHamiltonian
         NaN
     elseif b isa Function
         geometric_action(b, x, 1.0)
@@ -182,7 +182,7 @@ function _string_matrix(y::StateSpaceSet{D}, ::Val{D}, Nt::Int) where {D}
     return _string_matrix(m, D, Nt)
 end
 
-function _hp_mode(sys::ExtendedPhaseSpace, x::Matrix)
+function _hp_mode(sys::FreidlinWentzellHamiltonian, x::Matrix)
     D, Nt = size(x)
 
     y_m = sys.H_p(x, zeros(size(x)))
@@ -202,7 +202,7 @@ function _hp_mode(sys::ExtendedPhaseSpace, x::Matrix)
 
     throw(
         ArgumentError(
-            "`ExtendedPhaseSpace.H_p` must return either a $(D)×$(Nt) Matrix when given a Matrix state, or a $(Nt)×$(D) StateSpaceSet when given a StateSpaceSet state.",
+            "`FreidlinWentzellHamiltonian.H_p` must return either a $(D)×$(Nt) Matrix when given a Matrix state, or a $(Nt)×$(D) StateSpaceSet when given a StateSpaceSet state.",
         ),
     )
 end
@@ -230,7 +230,7 @@ function _init_string_integrator(sys::Function, x::Matrix; ϵ::Real, alg)
     )
 end
 
-function _init_string_integrator(sys::ExtendedPhaseSpace, x::Matrix; ϵ::Real, alg)
+function _init_string_integrator(sys::FreidlinWentzellHamiltonian, x::Matrix; ϵ::Real, alg)
     D, Nt = size(x)
     mode = _hp_mode(sys, x)
 

--- a/src/largedeviations/utils.jl
+++ b/src/largedeviations/utils.jl
@@ -67,17 +67,81 @@ function stepRK4!(u, b, Δt)
     return u
 end
 
+"""
+    proper_MAM_system(ds::CoupledSDEs)
+
+Validate that `ds` is admissible as input to the MAM / gMAM / sgMAM family.
+
+All variants require `:autonomous` noise. For systems with additive noise, `:invertible`
+must also hold (constant diffusion matrix must be invertible). For multiplicative /
+state-dependent noise, invertibility of ``a(x)`` along the path is the caller's
+responsibility.
+"""
 function proper_MAM_system(ds::CoupledSDEs)
-    for trait in (:additive, :invertible, :autonomous)
-        if !ds.noise_type[trait]
-            throw(
-                ArgumentError(
-                    "The minimal action method is only applicable for autonomous invertible additive noise. The noise type of the system is not $trait.",
-                ),
-            )
-        end
+    if !ds.noise_type[:autonomous]
+        throw(
+            ArgumentError(
+                "The minimal action method is only applicable for autonomous noise; the system's noise is non-autonomous.",
+            ),
+        )
+    end
+    if ds.noise_type[:additive] && !ds.noise_type[:invertible]
+        throw(
+            ArgumentError(
+                "The minimal action method requires an invertible constant diffusion matrix for additive noise.",
+            ),
+        )
     end
     return
+end
+
+# Helpers for the three-way dispatch on `a_func(x)` return types in the gMAM/sgMAM
+# solvers and action integrands:
+#
+#   * `nothing`         → additive a = I (shared tridiagonal / shared metric)
+#   * `AbstractVector`  → diagonal a(x) (per-DOF fast path)
+#   * `Diagonal`        → diagonal a(x) wrapped as a LinearAlgebra.Diagonal; we accept it
+#                         on the same fast path so hand-rolled `a_func(x) = Diagonal(...)`
+#                         doesn't silently fall into the slow general-matrix code path.
+#   * other `AbstractMatrix` → general state-dependent a(x) (sparse block-tridiagonal /
+#                              dense inverse).
+@inline _is_diagonal_a(a) = a isa AbstractVector || a isa LinearAlgebra.Diagonal
+@inline _diag_view(a::AbstractVector) = a
+@inline _diag_view(a::LinearAlgebra.Diagonal) = a.diag
+
+# Build a callable `x -> a_shape(x)` for the given system under convention B, where
+# `a_shape(x) = a(x) / s` and `s = L_1(a(x_0))/D` is the noise-magnitude scale extracted
+# at the reference state `x_0 = current_state(sys)`. Returns:
+#
+#   * `(nothing, :additive)`            for additive noise (a is constant; callers use
+#                                       their own precomputed `A = inv(a_shape)`).
+#   * `(callable -> Vector, :diagonal)` when `σσ'` is diagonal at the reference state.
+#   * `(callable -> Matrix, :general)`  otherwise.
+function _normalized_a_shape_func(sys::CoupledSDEs)
+    sys.noise_type[:additive] && return nothing, :additive
+    g = diffusion_function(sys)
+    params = current_parameters(sys)
+    σ0 = g(current_state(sys), params, 0.0)
+    a0 = σ0 * σ0'
+    s = LinearAlgebra.norm(a0, 1) / size(a0, 1)
+    if LinearAlgebra.isdiag(a0)
+        f = let g = g, params = params, s = s
+            x -> begin
+                σ = g(x, params, 0.0)
+                M = σ * σ'
+                [M[k, k] / s for k in 1:size(M, 1)]
+            end
+        end
+        return f, :diagonal
+    else
+        f = let g = g, params = params, s = s
+            x -> begin
+                σ = g(x, params, 0.0)
+                Matrix((σ * σ') / s)
+            end
+        end
+        return f, :general
+    end
 end
 
 function path_velocity!(v, path, time; order = 4)

--- a/src/sde_utils.jl
+++ b/src/sde_utils.jl
@@ -1,6 +1,7 @@
 StochasticSystemsBase = Base.get_extension(DynamicalSystemsBase, :StochasticSystemsBase)
 covariance_matrix = StochasticSystemsBase.covariance_matrix
 diffusion_matrix = StochasticSystemsBase.diffusion_matrix
+diffusion_function = StochasticSystemsBase.diffusion_function
 
 """
     StochSystem

--- a/test/code_quality.jl
+++ b/test/code_quality.jl
@@ -35,9 +35,11 @@ end
                 :EnsembleAlgorithm,
                 :Terminated,
                 :covariance_matrix,
+                :diffusion_function,
                 :diffusion_matrix,
                 :get_extension,
                 :register_error_hint,
+                Symbol("@deprecate_binding"),
             ),
         ),
     )

--- a/test/largedeviations/Maier_stein.jl
+++ b/test/largedeviations/Maier_stein.jl
@@ -59,3 +59,74 @@ using Test
         @test S(permutedims(Matrix(string.path))) > S(Matrix(Matrix(gm.path)'))
     end
 end # gMAM Meier Stein
+
+# Heymann-Vanden-Eijnden 2008 §4.1: at β = 1 the Maier-Stein drift is the gradient of
+# V(u,v) = -u²/2 + u⁴/4 + (1+u²)v²/2, with minima at (±1, 0) of V = -1/4 and a saddle at
+# (0, 0) of V = 0. For additive identity noise the geometric Freidlin-Wentzell action
+# from (-1, 0) to (+1, 0) is exactly 2·(V_saddle - V_min) = 1/2.
+#
+# This is also a regression test for issue #282: an earlier `FW_action` had a spurious
+# `/2`, which would make `mlp.action` come back as 1/4 instead of 1/2 here. We additionally
+# cross-check that the on-shell quadrature ⟨p, ẋ⟩ used by sgMAM agrees in absolute scale
+# with the path-based `fw_action` integrator on the same converged curve.
+@testset "Maier-Stein β=1 (gradient): analytic action = 1/2" begin
+    function meier_stein_grad(u, p, t)
+        x, y = u
+        return SA[x - x^3 - x * y^2, -(1 + x^2) * y]
+    end
+    sys = CoupledSDEs(meier_stein_grad, zeros(2); noise_strength = 1.0)
+    N = 100
+    xx = range(-1.0, 1.0; length = N)
+    yy = 0.3 .* (-xx .^ 2 .+ 1)
+    init = Matrix([xx yy]')
+
+    # gMAM (GeometricGradient): step-size 1.0 is fine; backtracking handles stability.
+    res_g = minimize_geometric_action(
+        sys, init, GeometricGradient(; stepsize = 1.0);
+        maxiters = 500, show_progress = false,
+    )
+    @test isapprox(res_g.action, 0.5; atol = 5.0e-3)
+
+    # sgMAM via Hamiltonian on the same system
+    sys_h = FreidlinWentzellHamiltonian(sys)
+    res_sg = minimize_simple_geometric_action(
+        sys_h, init, GeometricGradient(; stepsize = 1.0);
+        maxiters = 500, show_progress = false,
+    )
+    @test isapprox(res_sg.action, 0.5; atol = 5.0e-3)
+
+    # Issue #282: the sgMAM `mlp.action` (computed via FW_action(xdot, p)) must agree
+    # in absolute scale with the path-based fw_action integrator on the same curve.
+    # A spurious /2 in FW_action would make this ratio be 1/2 instead of 1.
+    sg_path = Matrix(Matrix(res_sg.path)')  # D × N
+    T_phys = 1.0  # action is parametrization-invariant on the minimizer
+    times = range(0.0, T_phys; length = size(sg_path, 2))
+    S_path = fw_action(sys, sg_path, times)
+    @test isapprox(res_sg.action, S_path; rtol = 1.0e-2)
+end
+
+# Heymann-Vanden-Eijnden 2008 eq. (3.8): "the error on the curve can be made O(Δα²) =
+# O(1/N²)". On the smooth β=1 gradient case we have the analytic action S = 1/2, so we
+# can check directly that doubling N reduces the action error by roughly 4×.
+@testset "gMAM second-order convergence in N (β=1 Maier-Stein)" begin
+    function meier_stein_grad(u, p, t)
+        x, y = u
+        return SA[x - x^3 - x * y^2, -(1 + x^2) * y]
+    end
+    sys = CoupledSDEs(meier_stein_grad, zeros(2); noise_strength = 1.0)
+    actions = Float64[]
+    for N in (60, 120)
+        xx = range(-1.0, 1.0; length = N)
+        yy = 0.3 .* (-xx .^ 2 .+ 1)
+        init = Matrix([xx yy]')
+        res = minimize_geometric_action(
+            sys, init, GeometricGradient(; stepsize = 1.0);
+            maxiters = 500, show_progress = false,
+        )
+        push!(actions, res.action)
+    end
+    err_coarse = abs(actions[1] - 0.5)
+    err_fine = abs(actions[2] - 0.5)
+    # Expect ~4× reduction; allow some slack since we're in the asymptotic regime.
+    @test err_fine < err_coarse / 2
+end

--- a/test/largedeviations/Maier_stein.jl
+++ b/test/largedeviations/Maier_stein.jl
@@ -95,14 +95,13 @@ end # gMAM Meier Stein
     )
     @test isapprox(res_sg.action, 0.5; atol = 5.0e-3)
 
-    # Issue #282: the sgMAM `mlp.action` (computed via FW_action(xdot, p)) must agree
-    # in absolute scale with the path-based fw_action integrator on the same curve.
-    # A spurious /2 in FW_action would make this ratio be 1/2 instead of 1.
+    # Issue #282: the sgMAM `mlp.action` (computed via FW_action(xdot, p) on the
+    # zero-energy shell) must agree in absolute scale with the parametrization-invariant
+    # `geometric_action` integrator on the same curve. A spurious /2 in FW_action would
+    # show up as a factor-of-2 mismatch between these two quantities.
     sg_path = Matrix(Matrix(res_sg.path)')  # D × N
-    T_phys = 1.0  # action is parametrization-invariant on the minimizer
-    times = range(0.0, T_phys; length = size(sg_path, 2))
-    S_path = fw_action(sys, sg_path, times)
-    @test isapprox(res_sg.action, S_path; rtol = 1.0e-2)
+    S_geom = geometric_action(sys, sg_path)
+    @test isapprox(res_sg.action, S_geom; rtol = 1.0e-2)
 end
 
 # Heymann-Vanden-Eijnden 2008 eq. (3.8): "the error on the curve can be made O(Δα²) =

--- a/test/largedeviations/multiplicative_noise.jl
+++ b/test/largedeviations/multiplicative_noise.jl
@@ -1,0 +1,274 @@
+using CriticalTransitions, StaticArrays
+using Test
+using LinearAlgebra
+using Random
+
+const CT = CriticalTransitions
+
+# Simple Simpson's rule for analytic baselines, avoiding an extra test dep
+function _simpson(f, a, b, n)
+    h = (b - a) / n
+    s = f(a) + f(b)
+    for i in 1:2:(n - 1)
+        s += 4 * f(a + i * h)
+    end
+    for i in 2:2:(n - 2)
+        s += 2 * f(a + i * h)
+    end
+    return s * h / 3
+end
+
+@testset "fw_action: state-dependent 1D OU vs analytic" begin
+    # SDE: dX = -X dt + sqrt(1 + α X²) dW;  a(x) = 1 + α x²
+    # Straight path x(t) = 1 - t over T = 1
+    α = 0.3
+    b1d(u, p, t) = SA[-u[1]]
+    g1d(u, p, t) = SA[sqrt(1 + α * u[1]^2);;]
+    ds = CoupledSDEs(b1d, SA[1.0]; g = g1d, noise_prototype = SMatrix{1, 1}(0.0))
+
+    N, T = 200, 1.0
+    path = reduce(hcat, range([1.0], [0.0]; length = N))
+    time = range(0.0, T; length = N)
+    S = fw_action(ds, path, time)
+
+    # Convention B: the FW rate function uses a_shape(x) = a(x)/s with s = a(u₀) at the
+    # system's reference state u₀ = 1.0. Here a(x) = 1 + α x², so s = 1 + α. Analytic:
+    #   S = (1/2) ∫₀¹ t² · s / (1 + α (1-t)²) dt  =  s · (1/2) ∫₀¹ t² / (1+α(1-t)²) dt.
+    integrand = t -> t^2 / (1 + α * (1 - t)^2)
+    s = 1 + α
+    analytic = s * _simpson(integrand, 0, 1, 10_000) / 2
+
+    @test isapprox(S, analytic; rtol = 1.0e-4)
+end
+
+@testset "geometric_action: additive limit recovers constant-Q value" begin
+    # When σ(x) is constant, the auto-dispatched multiplicative path must agree
+    # with the additive path (after matching the additive-side normalization).
+    p = [0.1, 3, 1, 1, 1, 0]
+    σ = 0.1
+    ds_add = CoupledSDEs(CT.CTLibrary.fitzhugh_nagumo, zeros(2), p; noise_strength = σ)
+
+    x_i = SA[sqrt(2 / 3), sqrt(2 / 27)]
+    x_f = SA[0.001, 0.0]
+    N = 60
+    path = reduce(hcat, range(x_i, x_f; length = N))
+
+    S_add = geometric_action(ds_add, path)
+
+    # Match the additive normalization in a manually-built multiplicative system.
+    Q = covariance_matrix(ds_add)
+    Q_norm = CT.normalize_covariance!(Matrix(Q))
+    σ_const = sqrt(Q_norm)
+    g_const(u, p, t) = SMatrix{2, 2}(σ_const)
+    ds_mul = CoupledSDEs(
+        CT.CTLibrary.fitzhugh_nagumo, zeros(2), p;
+        g = g_const, noise_prototype = SMatrix{2, 2}(zeros(2, 2)),
+    )
+
+    S_mul = geometric_action(ds_mul, path)
+    @test isapprox(S_add, S_mul; rtol = 1.0e-10)
+end
+
+@testset "minimize_action via Optimization.jl (multiplicative auto-dispatch)" begin
+    # With a constant σ that already matches the additive-side normalization,
+    # the multiplicative path must coincide with the additive minimizer.
+    Random.seed!(0)
+    σ = 0.18
+    ou_add = CoupledSDEs((u, p, t) -> -u, SA[1.0]; noise_strength = σ)
+    x0 = -1.0
+    xT = 2.0
+    T = 10.0
+    N = 51
+    res_ref = minimize_action(
+        ou_add, SA[x0], SA[xT], T; npoints = N, maxiters = 2000, show_progress = false
+    )
+
+    Q = covariance_matrix(ou_add)
+    Q_norm = CT.normalize_covariance!(Matrix(Q))
+    σ_const = sqrt(Q_norm[1, 1])
+    g_const(u, p, t) = SA[σ_const;;]
+    ou_mul = CoupledSDEs(
+        (u, p, t) -> -u, SA[1.0]; g = g_const, noise_prototype = SMatrix{1, 1}(0.0)
+    )
+
+    times = range(0.0, T; length = N)
+    S_with_a = fw_action(ou_mul, Matrix(res_ref.path)', times)
+    S_ref = fw_action(ou_add, Matrix(res_ref.path)', times)
+
+    @test isapprox(S_with_a, S_ref; rtol = 1.0e-10)
+end
+
+@testset "gMAM (GeometricGradient) diagonal multiplicative vs Adam" begin
+    using OptimizationOptimisers
+    Random.seed!(0)
+    α = 0.3
+    b1d(u, p, t) = SA[-u[1]]
+    g1d(u, p, t) = SA[sqrt(1 + α * u[1]^2);;]
+    ds = CoupledSDEs(b1d, SA[1.0]; g = g1d, noise_prototype = SMatrix{1, 1}(0.0))
+
+    N = 80
+    x_initial = reshape(collect(range(1.0, -1.0; length = N)), 1, N)
+
+    res_g = minimize_geometric_action(
+        ds, x_initial, GeometricGradient(; stepsize = 1.0);
+        maxiters = 500, show_progress = false,
+    )
+    res_ref = minimize_geometric_action(
+        ds, x_initial, OptimizationOptimisers.Adam(0.01);
+        maxiters = 3000, show_progress = false,
+    )
+    @test isapprox(res_g.action, res_ref.action; rtol = 0.05)
+end
+
+@testset "gMAM (GeometricGradient) general multiplicative vs Adam" begin
+    using OptimizationOptimisers
+    Random.seed!(0)
+    b2(u, p, t) = SA[-u[1], -u[2]]
+    function g2(u, p, t)
+        s11 = 1 + 0.2 * u[1]
+        s22 = 1 + 0.2 * u[2]
+        s12 = 0.3 * u[2]
+        s21 = 0.3 * u[1]
+        return @SMatrix [s11 s12; s21 s22]
+    end
+    ds = CoupledSDEs(b2, SA[1.0, 0.0]; g = g2, noise_prototype = SMatrix{2, 2}(zeros(2, 2)))
+
+    N = 60
+    xx = collect(range(1.0, 0.0; length = N))
+    yy = collect(range(0.0, 1.0; length = N))
+    x_initial = Matrix([xx yy]')
+
+    res_g = minimize_geometric_action(
+        ds, x_initial, GeometricGradient(; stepsize = 1.0);
+        maxiters = 300, show_progress = false,
+    )
+    res_ref = minimize_geometric_action(
+        ds, x_initial, OptimizationOptimisers.Adam(0.01);
+        maxiters = 3000, show_progress = false,
+    )
+    @test isfinite(res_g.action)
+    @test isapprox(res_g.action, res_ref.action; rtol = 0.1)
+end
+
+@testset "sgMAM diagonal multiplicative vs Adam reference" begin
+    using OptimizationOptimisers
+    Random.seed!(0)
+    α = 0.3
+    b1d(u, p, t) = SA[-u[1]]
+    g1d(u, p, t) = SA[sqrt(1 + α * u[1]^2);;]
+    ds = CoupledSDEs(b1d, SA[1.0]; g = g1d, noise_prototype = SMatrix{1, 1}(0.0))
+
+    sys = FreidlinWentzellHamiltonian(ds)
+    @test sys.a_func !== nothing
+    @test sys.a_func([0.5]) isa AbstractVector
+    # `a_func` returns the *shape* a(x)/s with s = a(u₀) at the reference state u₀ = 1.0.
+    # At x = 0.5: a(0.5)/s = (1 + α · 0.25) / (1 + α).
+    @test sys.a_func([0.5])[1] ≈ (1 + α * 0.5^2) / (1 + α)
+
+    N = 80
+    x_initial = reshape(collect(range(1.0, -1.0; length = N)), 1, N)
+
+    res_sg = minimize_simple_geometric_action(
+        sys, x_initial, GeometricGradient(; stepsize = 1.0);
+        maxiters = 500, show_progress = false,
+    )
+    res_ref = minimize_geometric_action(
+        ds, x_initial, OptimizationOptimisers.Adam(0.01);
+        maxiters = 3000, show_progress = false,
+    )
+    @test isapprox(res_sg.action, res_ref.action; rtol = 0.05)
+end
+
+@testset "sgMAM general (non-diagonal) multiplicative noise" begin
+    using OptimizationOptimisers
+    Random.seed!(0)
+    b2(u, p, t) = SA[-u[1], -u[2]]
+    function g2(u, p, t)
+        s11 = 1 + 0.2 * u[1]
+        s22 = 1 + 0.2 * u[2]
+        s12 = 0.3 * u[2]
+        s21 = 0.3 * u[1]
+        return @SMatrix [s11 s12; s21 s22]
+    end
+    ds = CoupledSDEs(b2, SA[1.0, 0.0]; g = g2, noise_prototype = SMatrix{2, 2}(zeros(2, 2)))
+
+    sys = FreidlinWentzellHamiltonian(ds)
+    @test sys.a_func([0.5, 0.3]) isa AbstractMatrix
+    @test !LinearAlgebra.isdiag(sys.a_func([0.5, 0.3]))
+
+    N = 60
+    xx = collect(range(1.0, 0.0; length = N))
+    yy = collect(range(0.0, 1.0; length = N))
+    x_initial = Matrix([xx yy]')
+
+    res_sg = minimize_simple_geometric_action(
+        sys, x_initial, GeometricGradient(; stepsize = 1.0);
+        maxiters = 300, show_progress = false,
+    )
+    @test isfinite(res_sg.action)
+
+    res_ref = minimize_geometric_action(
+        ds, x_initial, OptimizationOptimisers.Adam(0.01);
+        maxiters = 3000, show_progress = false,
+    )
+    @test isapprox(res_sg.action, res_ref.action; rtol = 0.1)
+end
+
+@testset "Multiplicative → additive limit (1D OU, sgMAM and gMAM)" begin
+    # For dX = -X dt + dW the geometric FW action from (1) to (-1) is
+    # 2·V(-1) = 1 (downhill 1 → 0 is free, uphill 0 → -1 costs 1). As α → 0,
+    # the multiplicative system dX = -X dt + √(1+αX²) dW must recover the same value.
+    additive(u, p, t) = SA[-u[1]]
+    ds_add = CoupledSDEs(additive, SA[1.0]; noise_strength = 1.0)
+
+    α_small = 1.0e-4
+    b1d(u, p, t) = SA[-u[1]]
+    g1d(u, p, t) = SA[sqrt(1 + α_small * u[1]^2);;]
+    ds_mul = CoupledSDEs(
+        b1d, SA[1.0]; g = g1d, noise_prototype = SMatrix{1, 1}(0.0)
+    )
+
+    N = 100
+    x_initial = reshape(collect(range(1.0, -1.0; length = N)), 1, N)
+
+    # gMAM: additive analytic value, multiplicative converges to additive as α → 0.
+    res_add_g = minimize_geometric_action(
+        ds_add, x_initial, GeometricGradient(; stepsize = 1.0);
+        maxiters = 500, show_progress = false,
+    )
+    res_mul_g = minimize_geometric_action(
+        ds_mul, x_initial, GeometricGradient(; stepsize = 1.0);
+        maxiters = 500, show_progress = false,
+    )
+    @test isapprox(res_add_g.action, 1.0; atol = 3.0e-2)
+    @test isapprox(res_mul_g.action, res_add_g.action; atol = 5.0e-3)
+
+    # sgMAM: same check via the Hamiltonian path.
+    sys_add = FreidlinWentzellHamiltonian(ds_add)
+    sys_mul = FreidlinWentzellHamiltonian(ds_mul)
+    res_add_sg = minimize_simple_geometric_action(
+        sys_add, x_initial, GeometricGradient(; stepsize = 1.0);
+        maxiters = 500, show_progress = false,
+    )
+    res_mul_sg = minimize_simple_geometric_action(
+        sys_mul, x_initial, GeometricGradient(; stepsize = 1.0);
+        maxiters = 500, show_progress = false,
+    )
+    @test isapprox(res_add_sg.action, 1.0; atol = 3.0e-2)
+    @test isapprox(res_mul_sg.action, res_add_sg.action; atol = 5.0e-3)
+end
+
+@testset "FreidlinWentzellHamiltonian deprecation alias" begin
+    H_x(x, p) = zeros(size(x))
+    H_p(x, p) = ones(size(x))
+
+    # The new name works.
+    sys_new = FreidlinWentzellHamiltonian{false, 2}(H_x, H_p)
+    @test sys_new isa FreidlinWentzellHamiltonian
+
+    # The old name is a deprecation alias. Compare type names rather than `===` so the
+    # test is robust to in-session struct redefinitions (the alias would otherwise be
+    # pinned to an older world age and fail strict identity).
+    @test nameof(Base.unwrap_unionall(ExtendedPhaseSpace)) ===
+        nameof(Base.unwrap_unionall(FreidlinWentzellHamiltonian))
+end

--- a/test/largedeviations/multiplicative_noise.jl
+++ b/test/largedeviations/multiplicative_noise.jl
@@ -257,18 +257,3 @@ end
     @test isapprox(res_add_sg.action, 1.0; atol = 3.0e-2)
     @test isapprox(res_mul_sg.action, res_add_sg.action; atol = 5.0e-3)
 end
-
-@testset "FreidlinWentzellHamiltonian deprecation alias" begin
-    H_x(x, p) = zeros(size(x))
-    H_p(x, p) = ones(size(x))
-
-    # The new name works.
-    sys_new = FreidlinWentzellHamiltonian{false, 2}(H_x, H_p)
-    @test sys_new isa FreidlinWentzellHamiltonian
-
-    # The old name is a deprecation alias. Compare type names rather than `===` so the
-    # test is robust to in-session struct redefinitions (the alias would otherwise be
-    # pinned to an older world age and fail strict identity).
-    @test nameof(Base.unwrap_unionall(ExtendedPhaseSpace)) ===
-        nameof(Base.unwrap_unionall(FreidlinWentzellHamiltonian))
-end

--- a/test/largedeviations/sgMAM.jl
+++ b/test/largedeviations/sgMAM.jl
@@ -3,7 +3,7 @@ using ModelingToolkit
 using Test
 using LinearAlgebra
 
-@testset "ExtendedPhaseSpace KPO" begin
+@testset "FreidlinWentzellHamiltonian KPO" begin
     λ = 3 / 1.21 * 2 / 295
     ω0 = 1.0
     ω = 1.0
@@ -51,8 +51,8 @@ using LinearAlgebra
     prob = ODEProblem(sysMTK, Dict(sts .=> zeros(2)), (0.0, 100.0); jac = true)
     ds = CoupledODEs(prob)
 
-    sys = ExtendedPhaseSpace{false, 2}(H_x, H_p)
-    sys′ = ExtendedPhaseSpace(ds)
+    sys = FreidlinWentzellHamiltonian{false, 2}(H_x, H_p)
+    sys′ = FreidlinWentzellHamiltonian(ds)
 
     Nt = 500  # number of discrete time steps
     p_r = rand(2, Nt)
@@ -71,7 +71,7 @@ using LinearAlgebra
     @test [result_H_p[2, :]'; result_H_p[1, :]'] ≈ sys.H_p(x_r, p_r)
 end
 
-@testset "ExtendedPhaseSpace MTK" begin
+@testset "FreidlinWentzellHamiltonian MTK" begin
     @independent_variables t
     D = Differential(t)
     sts = @variables u(t) v(t)
@@ -89,7 +89,7 @@ end
     @mtkcompile sysMTK = System(eqs, t)
     prob = ODEProblem(sysMTK, Dict(sts .=> zeros(2)), (0.0, 100.0); jac = true)
     ds = CoupledODEs(prob)
-    sys = ExtendedPhaseSpace(ds)
+    sys = FreidlinWentzellHamiltonian(ds)
 
     @test sys.H_x(zeros(2), zeros(2)) ≈ zeros(2)
     @test sys.H_p(zeros(2), zeros(2)) ≈ zeros(2)
@@ -98,7 +98,7 @@ end
 @testset "sgMAM GeometricGradient" begin
     H_x(x, p) = zeros(size(x))
     H_p(x, p) = ones(size(x))
-    sys = ExtendedPhaseSpace{false, 2}(H_x, H_p)
+    sys = FreidlinWentzellHamiltonian{false, 2}(H_x, H_p)
 
     xx = collect(range(-1.0, 1.0; length = 20))
     yy = 0.3 .* (-xx .^ 2 .+ 1)
@@ -134,7 +134,7 @@ end
 
     σ = 0.25
     ds = CoupledSDEs(meier_stein, zeros(2); noise_strength = σ)
-    sys = ExtendedPhaseSpace(ds)
+    sys = FreidlinWentzellHamiltonian(ds)
 
     xx = range(-1.0, 1.0; length = 60)
     yy = 0.3 .* (-xx .^ 2 .+ 1)
@@ -196,7 +196,7 @@ end
     end
     σ = 0.25
     ds = CoupledSDEs(meier_stein, zeros(2); noise_strength = σ)
-    sys = ExtendedPhaseSpace(ds)
+    sys = FreidlinWentzellHamiltonian(ds)
 
     xx = range(-1.0, 1.0; length = 60)
     yy = 0.3 .* (-xx .^ 2 .+ 1)
@@ -227,7 +227,7 @@ end
     end
     σ = 0.25
     ds = CoupledSDEs(meier_stein, zeros(2); noise_strength = σ)
-    sys = ExtendedPhaseSpace(ds)
+    sys = FreidlinWentzellHamiltonian(ds)
 
     xx = range(-1.0, 1.0; length = 60)
     yy = 0.3 .* (-xx .^ 2 .+ 1)

--- a/test/largedeviations/string_method.jl
+++ b/test/largedeviations/string_method.jl
@@ -52,7 +52,7 @@ yy = @. (xb[2] - xa[2]) * s + xa[2] + 4 * s * (1 - s) * xsaddle[2] + 0.01 * sin(
         return StateSpaceSet([H_pu H_pv])
     end
 
-    sys_sss = ExtendedPhaseSpace{false, 2}(H_x_sss, H_p_sss)
+    sys_sss = FreidlinWentzellHamiltonian{false, 2}(H_x_sss, H_p_sss)
 
     x_init_sss = StateSpaceSet([xx yy])
 
@@ -77,7 +77,7 @@ yy = @. (xb[2] - xa[2]) * s + xa[2] + 4 * s * (1 - s) * xsaddle[2] + 0.01 * sin(
         return Matrix([H_pu H_pv]')
     end
 
-    sys_m = ExtendedPhaseSpace{false, 2}(H_x_m, H_p_m)
+    sys_m = FreidlinWentzellHamiltonian{false, 2}(H_x_m, H_p_m)
 
     x_init_m = Matrix([xx yy]')
 
@@ -145,7 +145,7 @@ end
     @test norm(vec(Matrix(string_default.path)) - vec(Matrix(string_tsit5.path))) > 1.0e-10
 end
 
-@testset "ExtendedPhaseSpace supports integrator" begin
+@testset "FreidlinWentzellHamiltonian supports integrator" begin
     D = 2
     Nt_small = 40
     s_small = range(0; stop = 1, length = Nt_small)
@@ -155,7 +155,7 @@ end
 
     H_x_m(x, p) = zeros(size(x))
     H_p_m(x, p) = -x
-    sys_m = ExtendedPhaseSpace{false, 2}(H_x_m, H_p_m)
+    sys_m = FreidlinWentzellHamiltonian{false, 2}(H_x_m, H_p_m)
 
     H_x_sss(x, p) = StateSpaceSet(zeros(length(x), D))
     function H_p_sss(x, p)
@@ -164,7 +164,7 @@ end
         # regardless of whether Matrix(StateSpaceSet) returns D×Nt or Nt×D.
         return size(m, 1) == length(x) ? StateSpaceSet(-m) : StateSpaceSet(-permutedims(m))
     end
-    sys_sss = ExtendedPhaseSpace{false, 2}(H_x_sss, H_p_sss)
+    sys_sss = FreidlinWentzellHamiltonian{false, 2}(H_x_sss, H_p_sss)
 
     string_euler_m = string_method(
         sys_m,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ end
     include("largedeviations/MAM.jl")
     include("largedeviations/gMAM.jl")
     include("largedeviations/sgMAM.jl")
+    include("largedeviations/multiplicative_noise.jl")
     include("largedeviations/string_method.jl")
     include("largedeviations/Maier_stein.jl")
     include("largedeviations/interpolate.jl")


### PR DESCRIPTION
resolves #282, #130, #275 


- [ ] `_update_x_general!`: cache the sparse block-tridiagonal pattern. Currently
  `sparse(Iv, Jv, Vv, n, n)` rebuilds the matrix every iteration even though the
  sparsity pattern is fixed. Build `M` and the COO→nzval index map once, then
  overwrite `M.nzval` in place per iteration; reuse a LinearSolve cache so the
  symbolic factorization is shared.
- [ ] `_update_x_diag!`: mirror the additive path's LinearSolve cache. The diagonal
  per-DOF tridiagonal solve currently allocates fresh `Tridiagonal` buffers and
  uses `T_dof \ rhs` without a `LinearProblem` cache; the additive path already
  shows the pattern with `alias_A = true`.
-   [ ] Uniformise the `A` kwarg on `geometric_action(b::Function, ...)` to a single
  type: a callable `x -> a(x)` returning the (uninverted) covariance, with default
  `Returns(LinearAlgebra.I)`. Drop the `A=nothing` and `A::AbstractMatrix` branches;
  constants are wrapped via `Returns(a)`. Mirrors the DSB.jl PR #212 design (single
  covariance entry point) and the discussion in #196.
- [ ] Apply the same treatment to any other public covariance-kwarg surfaces added
  on this branch (e.g. `a_func` in `FreidlinWentzellHamiltonian`, which currently
  dispatches three ways on the return type of `a_func(x)`).