### PR TITLE
fix: Freidlin-Wentzell action conventions and /2 bugs

### DIFF
--- a/docs/src/man/largedeviations.md
+++ b/docs/src/man/largedeviations.md
@@ -11,6 +11,66 @@ This section applies results of large deviation theory (LDT), particularly actio
 
     This is a special case of the broader class of noise types supported by [`CoupledSDEs`](@ref).
 
+!!! note "Noise convention used by the action functionals"
+    **Starting point.** A [`CoupledSDEs`](@ref) exposes its noise via the diffusion
+    function ``g`` and, for additive invertible noise, the noise rate covariance
+    ```math
+    \mathbf{\Sigma} \;=\; \texttt{covariance\_matrix(sys)} \;=\; g\,g^\top.
+    ```
+    For an SDE built as ``\mathrm{d}\mathbf{x} = \mathbf{b}\,\mathrm{d}t + \sigma\,\mathbf{\Sigma}_0\,\mathrm{d}\mathbf{W}_t``
+    with ``\mathbf{\Sigma}_0\mathbf{\Sigma}_0^\top = \mathbf{Q}``, this gives ``\mathbf{\Sigma} = \sigma^2\,\mathbf{Q}``.
+    The Freidlin–Wentzell rate function only depends on the *product* ``\sigma^2\mathbf{Q}``;
+    the individual ``(\sigma, \mathbf{Q})`` split is not determined by the SDE alone
+    (``(\sigma, \mathbf{Q}) \leftrightarrow (c\sigma, \mathbf{Q}/c^2)`` is the same physical system).
+
+    **Convention.** The package picks a unique ``(\sigma, \mathbf{Q})`` pair from ``\mathbf{\Sigma}``
+    by adopting the **trace convention** ``\mathrm{tr}(\mathbf{Q}) = D``:
+    ```math
+    \sigma_{\mathrm{eff}}^2 \;=\; \frac{\mathrm{tr}(\mathbf{\Sigma})}{D},
+    \qquad
+    \mathbf{Q}_{\mathrm{can}} \;=\; \frac{D}{\mathrm{tr}(\mathbf{\Sigma})}\,\mathbf{\Sigma}.
+    ```
+    The accessor [`noise_strength`](@ref)`(sys)` returns ``\sigma_{\mathrm{eff}}``. The trace is
+    invariant under orthogonal changes of basis and reduces to the per-direction average
+    noise variance, making this the natural choice among rotation-invariant normalizations.
+
+    **Action functionals use the canonical covariance.** All action functionals in this
+    section evaluate the FW integrand in the ``\mathbf{Q}_{\mathrm{can}}^{-1}`` metric:
+    ```math
+    \texttt{fw\_action(sys, path, time)} \;=\; \Phi_{FW}^{\mathbf{Q}_{\mathrm{can}}}[\phi] \;=\;
+        \tfrac{1}{2}\!\int (\dot\phi - \mathbf{b})^\top \mathbf{Q}_{\mathrm{can}}^{-1}(\dot\phi - \mathbf{b})\,\mathrm{d}t.
+    ```
+    Two consequences:
+
+    - The returned action is **independent of the `noise_strength` keyword** chosen at
+      construction (both ``\sigma`` and the magnitude of ``\mathbf{Q}`` are absorbed into
+      ``\sigma_{\mathrm{eff}}``).
+    - The returned action is **invariant under orthogonal changes of basis**, matching
+      the coordinate-independence of the FW action as a geometric quantity.
+
+    **Converting to the user's parameterization.** If you built your system as
+    ``\mathrm{d}\mathbf{x} = \mathbf{b}\,\mathrm{d}t + \sigma_{\mathrm{user}}\,\mathbf{\Sigma}_0\,\mathrm{d}\mathbf{W}_t``
+    with ``\mathbf{Q}_{\mathrm{user}} = \mathbf{\Sigma}_0\mathbf{\Sigma}_0^\top`` and want the FW action in
+    *your* metric ``\mathbf{Q}_{\mathrm{user}}^{-1}``, multiply the returned action by
+    ``\mathrm{tr}(\mathbf{Q}_{\mathrm{user}})/D``:
+    ```math
+    \Phi_{FW}^{\mathbf{Q}_{\mathrm{user}}}[\phi] \;=\; \frac{\mathrm{tr}(\mathbf{Q}_{\mathrm{user}})}{D}\cdot
+        \texttt{fw\_action(sys, path, time)}.
+    ```
+    The factor is ``1`` whenever ``\mathbf{Q}_{\mathrm{user}}`` is isotropic (``c\,\mathbf{I}`` for any
+    ``c>0``) or already trace-normalized (``\mathrm{tr}(\mathbf{Q}_{\mathrm{user}}) = D``), in which
+    case `fw_action` returns ``\Phi_{FW}^{\mathbf{Q}_{\mathrm{user}}}`` directly. All examples and
+    tests in the package fall in this case.
+
+    **`fw_action` vs `om_action`.** [`fw_action`](@ref) and [`geometric_action`](@ref) are
+    fully ``\sigma``-independent under this convention. [`om_action`](@ref) takes
+    `noise_strength` as an explicit positional argument because the Onsager–Machlup
+    correction ``(\sigma^2/2)\int \nabla\cdot \mathbf{b}\,\mathrm{d}t`` is a *finite-noise*
+    correction that scales with ``\sigma^2``; only the FW part of OM is ``\sigma``-independent.
+    Pass the ``\sigma`` at which you want ``-\log P[\phi]`` evaluated (typically the same
+    `noise_strength` you used at construction). As ``\sigma \to 0`` the OM correction
+    vanishes and OM ``\to`` FW, recovering the leading-order LDP rate function.
+
 ## Action minimizers
 Several methods have been proposed to calculate transition paths that minimize a given [action functional](@ref "Action functionals"). In the weak-noise limit, this minimum action path (or instanton) corresponds to the most probable transition path. While the minimum action method (MAM) is the most basic version, it is often beneficial to minimize the [geometric action](@ref "Geometric Freidlin-Wentzell action") via a time-independent version called gMAM. The problem can also be cast in a Hamiltonian form, implemented as simple gMAM (sgMAM), which can have numerical advantages.
 

--- a/docs/src/man/system_construction.md
+++ b/docs/src/man/system_construction.md
@@ -41,6 +41,7 @@ div_drift
 StochasticSystemsBase.covariance_matrix
 StochasticSystemsBase.diffusion_matrix
 noise_process
+noise_strength
 ```
 
 ## Non-autonomous: `RateSystem`

--- a/src/CriticalTransitions.jl
+++ b/src/CriticalTransitions.jl
@@ -88,7 +88,7 @@ using .CTLibrary
 
 # Core types
 export CoupledSDEs, CoupledODEs, noise_process, covariance_matrix, diffusion_matrix
-export drift, div_drift, solver
+export drift, div_drift, solver, noise_strength
 export StateSpaceSet
 
 export minimize_simple_geometric_action, ExtendedPhaseSpace

--- a/src/largedeviations/action.jl
+++ b/src/largedeviations/action.jl
@@ -2,8 +2,8 @@
 $(TYPEDSIGNATURES)
 
 Calculates the Freidlin-Wentzell action of a given `path` with time points `time` in a
-drift field specified by the deterministic dynamics `f = dynamic_rule(sys)` and
-(normalized) noise covariance matrix `covariance_matrix(sys)`.
+drift field specified by the deterministic dynamics `f = dynamic_rule(sys)` and the
+(canonicalized) noise covariance matrix `covariance_matrix(sys)`.
 
 The path must be a `(D x N)` matrix, where `D` is the dimensionality of the system `sys` and
 `N` is the number of path points. The `time` array must have length `N`.
@@ -13,10 +13,16 @@ Returns a single number, which is the value of the action functional
 ``S_T[\\phi_t] = \\frac{1}{2} \\int_0^T || \\dot \\phi_t - f(\\phi_t) ||^2_Q \\text{d}t``
 
 where ``\\phi_t`` denotes the path in state space, ``b`` the drift field, and ``T`` the
-total time of the path. The subscript ``Q`` refers to the
-generalized norm ``||a||_Q^2 := \\langle a, Q^{-1} b \\rangle`` (see `anorm`). Here
-``Q`` is the noise covariance matrix normalized by ``D/L_1(Q)``, with ``L_1`` being the
-L1 matrix norm.
+total time of the path. The subscript ``Q`` refers to the generalized norm
+``||a||_Q^2 := \\langle a, Q^{-1} a \\rangle`` (see `anorm`). Here ``Q`` is the noise
+covariance matrix normalized so that ``\\mathrm{tr}(Q) = D``. This canonicalization
+fixes the ``(\\varepsilon, a_0) \\leftrightarrow (c\\varepsilon, a_0/c)`` ambiguity
+inherent to Freidlin-Wentzell theory and makes the action independent of the
+`noise_strength` chosen at construction time. Under this convention,
+``S_T = \\Phi_{FW}`` exactly on the instanton for the canonicalized ``Q``.
+
+To recover the FW action for a non-canonical user covariance ``Q_{\\mathrm{user}}``,
+multiply by ``\\mathrm{tr}(Q_{\\mathrm{user}})/D``.
 """
 function fw_action(sys::CoupledSDEs, path, time)
     @assert all(diff(time) .≈ diff(time[1:2])) "Freidlin-Wentzell action is only defined for equispaced time"
@@ -48,15 +54,15 @@ Returns a single number, which is the value of the action functional
 
 where ``\\phi_t`` denotes the path in state space, ``b`` the drift field, ``T`` the total
 time of the path, and ``\\sigma`` the noise strength. The subscript ``Q`` refers to the
-generalized norm ``||a||_Q^2 := \\langle a, Q^{-1} b \\rangle`` (see `anorm`). Here
-``Q`` is the noise covariance matrix normalized by ``D/L_1(Q)``, with ``L_1`` being the
-L1 matrix norm.
+generalized norm ``||a||_Q^2 := \\langle a, Q^{-1} a \\rangle`` (see `anorm`). Here ``Q``
+is the noise covariance matrix normalized so that ``\\mathrm{tr}(Q) = D`` (see
+[`fw_action`](@ref) for the rationale).
 """
 function om_action(sys::CoupledSDEs, path, time, noise_strength)
     @assert all(diff(time) .≈ diff(time[1:2])) "Onsager-Machlup action is only defined for equispaced time"
 
     σ = noise_strength
-    # Compute action integral
+    # Trapezoidal quadrature of (σ²/2) ∫ ∇·f dt
     S = 0.0
     for i in 1:(size(path, 2) - 1)
         S +=
@@ -65,7 +71,7 @@ function om_action(sys::CoupledSDEs, path, time, noise_strength)
                 (time[i + 1] - time[i])
         )
     end
-    return fw_action(sys, path, time) + S / 2
+    return fw_action(sys, path, time) + S
 end;
 
 """
@@ -104,9 +110,8 @@ by the integral
 
 where ``s`` is the arclength coordinate, ``L`` the arclength, ``f`` the drift field, and the
 subscript ``Q`` refers to the generalized dot product ``\\langle a, b \\rangle_Q := a^{\\top}
-\\cdot Q^{-1} b`` (see `anorm`). Here
-``Q`` is the noise covariance matrix normalized by ``D/L_1(Q)``, with ``L_1`` being the
-L1 matrix norm.
+\\cdot Q^{-1} b`` (see `anorm`). Here ``Q`` is the noise covariance matrix normalized so that
+``\\mathrm{tr}(Q) = D`` (see [`fw_action`](@ref) for the rationale).
 
 Returns the value of the geometric action ``\\bar S``.
 """

--- a/src/largedeviations/action.jl
+++ b/src/largedeviations/action.jl
@@ -1,28 +1,19 @@
 """
 $(TYPEDSIGNATURES)
 
-Calculates the Freidlin-Wentzell action of a given `path` with time points `time` in a
-drift field specified by the deterministic dynamics `f = dynamic_rule(sys)` and the
-(canonicalized) noise covariance matrix `covariance_matrix(sys)`.
+Freidlin-Wentzell action of `path` (a `D × N` matrix with `D = dimension(sys)`) with time
+points `time` (length `N`) for the drift `b = dynamic_rule(sys)`:
 
-The path must be a `(D x N)` matrix, where `D` is the dimensionality of the system `sys` and
-`N` is the number of path points. The `time` array must have length `N`.
+```math
+S_T[\\phi] \\;=\\; \\tfrac{1}{2}\\int_0^T \\big\\| \\dot\\phi - \\mathbf{b}(\\phi)\\big\\|_\\mathbf{Q}^2 \\,\\mathrm{d}t
+```
 
-Returns a single number, which is the value of the action functional
-
-``S_T[\\phi_t] = \\frac{1}{2} \\int_0^T || \\dot \\phi_t - f(\\phi_t) ||^2_Q \\text{d}t``
-
-where ``\\phi_t`` denotes the path in state space, ``b`` the drift field, and ``T`` the
-total time of the path. The subscript ``Q`` refers to the generalized norm
-``||a||_Q^2 := \\langle a, Q^{-1} a \\rangle`` (see `anorm`). Here ``Q`` is the noise
-covariance matrix normalized so that ``\\mathrm{tr}(Q) = D``. This canonicalization
-fixes the ``(\\varepsilon, a_0) \\leftrightarrow (c\\varepsilon, a_0/c)`` ambiguity
-inherent to Freidlin-Wentzell theory and makes the action independent of the
-`noise_strength` chosen at construction time. Under this convention,
-``S_T = \\Phi_{FW}`` exactly on the instanton for the canonicalized ``Q``.
-
-To recover the FW action for a non-canonical user covariance ``Q_{\\mathrm{user}}``,
-multiply by ``\\mathrm{tr}(Q_{\\mathrm{user}})/D``.
+where ``\\|a\\|_\\mathbf{Q}^2 = \\langle a, \\mathbf{Q}^{-1} a\\rangle`` (see `anorm`), ``T`` is the
+total time of the path, and ``\\mathbf{Q}`` is the trace-normalized `covariance_matrix(sys)`
+(see [`normalize_covariance!`](@ref)). The convention makes the returned value independent
+of the `noise_strength` keyword and invariant under orthogonal changes of basis. See
+[Large deviation theory](@ref) for the convention and the conversion to a user-supplied
+``\\mathbf{Q}_{\\mathrm{user}}``.
 """
 function fw_action(sys::CoupledSDEs, path, time)
     @assert all(diff(time) .≈ diff(time[1:2])) "Freidlin-Wentzell action is only defined for equispaced time"
@@ -42,21 +33,21 @@ end;
 """
     om_action(sys::CoupledSDEs, path, time, noise_strength)
 
-Calculates the Onsager-Machlup action of a given `path` with time points `time` for the drift field `f = dynamic_rule(sys)` at given `noise_strength`.
+Onsager-Machlup action of `path` (a `D × N` matrix) with time points `time` (length `N`)
+for the drift `b = dynamic_rule(sys)`, at the given `noise_strength` σ:
 
-The path must be a `(D x N)` matrix, where `D` is the dimensionality of the system `sys` and
-`N` is the number of path points. The `time` array must have length `N`.
+```math
+S^\\sigma_T[\\phi] \\;=\\; \\tfrac{1}{2}\\int_0^T \\Big(\\big\\|\\dot\\phi - \\mathbf{b}(\\phi)\\big\\|_\\mathbf{Q}^2
+    \\;+\\; \\sigma^2 \\,\\nabla\\cdot \\mathbf{b}(\\phi)\\Big)\\,\\mathrm{d}t
+```
 
-Returns a single number, which is the value of the action functional
-
-``S^{\\sigma}_T[\\phi_t] = \\frac{1}{2} \\int_0^T \\left( || \\dot \\phi_t - f(\\phi_t) ||^2_Q +
-\\sigma^2 \\nabla \\cdot f \\right) \\, \\text{d} t``
-
-where ``\\phi_t`` denotes the path in state space, ``b`` the drift field, ``T`` the total
-time of the path, and ``\\sigma`` the noise strength. The subscript ``Q`` refers to the
-generalized norm ``||a||_Q^2 := \\langle a, Q^{-1} a \\rangle`` (see `anorm`). Here ``Q``
-is the noise covariance matrix normalized so that ``\\mathrm{tr}(Q) = D`` (see
-[`fw_action`](@ref) for the rationale).
+where ``\\|a\\|_\\mathbf{Q}^2 = \\langle a, \\mathbf{Q}^{-1} a\\rangle`` (see `anorm`), ``T`` is the
+total time, and ``\\mathbf{Q}`` is the trace-normalized `covariance_matrix(sys)`. The first
+term is exactly [`fw_action`](@ref) and is independent of the `noise_strength` keyword
+under the trace-normalize convention. The second term is the Onsager-Machlup finite-noise
+correction parameterized by the explicit `noise_strength` argument: pass the σ at which
+you want ``-\\log P[\\phi]`` evaluated (typically the same `noise_strength` you used at
+construction). As ``\\sigma \\to 0``, `om_action` → `fw_action`.
 """
 function om_action(sys::CoupledSDEs, path, time, noise_strength)
     @assert all(diff(time) .≈ diff(time[1:2])) "Onsager-Machlup action is only defined for equispaced time"
@@ -96,24 +87,19 @@ end;
 """
 $(TYPEDSIGNATURES)
 
-Calculates the geometric action of a given `path` with specified `arclength` for the drift
-field specified by the deterministic dynamics `f = dynamic_rule(sys)` and
-(normalized) noise covariance matrix `covariance_matrix(sys)`.
+Geometric Freidlin-Wentzell action of `path` (a `D × N` matrix) with the given `arclength`,
+for the drift `b = dynamic_rule(sys)`. Equals ``\\inf_T S_T[\\varphi]`` of the
+time-parameterized [`fw_action`](@ref) on the instanton:
 
-For a given path ``\\varphi``, the geometric action ``\\bar S`` corresponds to the minimum
-of the Freidlin-Wentzell action ``S_T(\\varphi)`` over all travel times ``T>0``, where ``\\varphi``
-denotes the path's parameterization in physical time (see [`fw_action`](@ref)). It is given
-by the integral
+```math
+\\bar S[\\varphi] \\;=\\; \\int_0^L \\Big( \\|\\varphi'\\|_\\mathbf{Q}\\,\\|\\mathbf{b}(\\varphi)\\|_\\mathbf{Q}
+    \\;-\\; \\langle \\varphi', \\mathbf{b}(\\varphi)\\rangle_\\mathbf{Q} \\Big)\\,\\mathrm{d}s
+```
 
-``\\bar S[\\varphi] = \\int_0^L \\left( ||\\varphi'||_Q \\, ||f(\\varphi)||_Q - \\langle \\varphi', \\,
-    f(\\varphi) \\rangle_Q \\right) \\, \\text{d}s``
-
-where ``s`` is the arclength coordinate, ``L`` the arclength, ``f`` the drift field, and the
-subscript ``Q`` refers to the generalized dot product ``\\langle a, b \\rangle_Q := a^{\\top}
-\\cdot Q^{-1} b`` (see `anorm`). Here ``Q`` is the noise covariance matrix normalized so that
-``\\mathrm{tr}(Q) = D`` (see [`fw_action`](@ref) for the rationale).
-
-Returns the value of the geometric action ``\\bar S``.
+where ``s`` is the arclength coordinate, ``L`` the arclength, and ``\\|a\\|_\\mathbf{Q}^2 =
+\\langle a, b\\rangle_\\mathbf{Q} = a^\\top \\mathbf{Q}^{-1} b`` (see `anorm`). ``\\mathbf{Q}`` is the
+trace-normalized `covariance_matrix(sys)`. As with [`fw_action`](@ref), the returned value
+is independent of the `noise_strength` keyword and rotation-invariant.
 """
 function geometric_action(sys::CoupledSDEs, path, arclength = 1.0)
     A = inv(normalize_covariance!(covariance_matrix(sys)))

--- a/src/largedeviations/sgMAM.jl
+++ b/src/largedeviations/sgMAM.jl
@@ -258,7 +258,12 @@ function _sgmam_refresh!(xdot, p, lambda, x, H_p)
     return nothing
 end
 
-FW_action(xdot, p) = dot(xdot, p) / 2
+# Freidlin-Wentzell action of an instanton path discretized over a uniform arclength
+# parameter `s ∈ [0, 1]`. With `xdot` produced by `central_diff!` (which does not
+# divide by Δs), `xdot[:, i] ≈ Δs · dϕ/ds`, so `dot(xdot, p) ≈ ∫ p · dϕ`. On the
+# zero-energy shell `H = p·f + |p|²/2 = 0`, the identity `p · dϕ = (|p|²/2) dt`
+# holds along the instanton, so `∫ p · dϕ = ½ ∫ |p|² dt = S_FW`. No additional `/2`.
+FW_action(xdot, p) = dot(xdot, p)
 
 function proper_sgMAM_system(ds::CoupledSDEs)
     proper_MAM_system(ds)

--- a/src/sde_utils.jl
+++ b/src/sde_utils.jl
@@ -43,3 +43,27 @@ $(TYPEDSIGNATURES)
 Returns the SDE solver specified in the `diffeq` settings of the `CoupledSDEs`.
 """
 solver(ds::ContinuousTimeDynamicalSystem) = ds.integ.alg
+
+"""
+$(TYPEDSIGNATURES)
+
+Returns the effective noise strength ``\\sigma_{\\mathrm{eff}}`` of the `CoupledSDEs`
+`sys`, defined as ``\\sigma_{\\mathrm{eff}} = \\sqrt{\\mathrm{tr}(\\Sigma)/D}`` where
+``\\Sigma = `` `covariance_matrix(sys)` is the SDE's noise rate matrix and `D` its
+state-space dimension.
+
+This is the σ produced by the trace-normalization convention used in the large-deviation
+action functionals (see [`fw_action`](@ref)): the SDE
+``\\mathrm{d}x = b\\,\\mathrm{d}t + \\sigma\\,\\Sigma_0\\,\\mathrm{d}W`` is canonicalized as
+``\\sigma_{\\mathrm{eff}}^2 = \\mathrm{tr}(\\sigma^2\\,Q)/D`` with
+``Q = \\Sigma_0\\Sigma_0^\\top``. For an SDE constructed with isotropic `covariance = I`,
+`noise_strength(sys)` recovers the `noise_strength` keyword passed at construction time.
+More generally, the returned value is the per-direction average of the noise variance.
+
+For an SDE built with a custom `g` that is not of the form `σ * sqrt(Q)`, the returned
+value is still the trace-based effective σ of the resulting covariance matrix.
+"""
+function noise_strength(sys::CoupledSDEs)
+    Σ = covariance_matrix(sys)
+    return sqrt(tr(Σ) / size(Σ, 1))
+end

--- a/src/sde_utils.jl
+++ b/src/sde_utils.jl
@@ -47,21 +47,24 @@ solver(ds::ContinuousTimeDynamicalSystem) = ds.integ.alg
 """
 $(TYPEDSIGNATURES)
 
-Returns the effective noise strength ``\\sigma_{\\mathrm{eff}}`` of the `CoupledSDEs`
-`sys`, defined as ``\\sigma_{\\mathrm{eff}} = \\sqrt{\\mathrm{tr}(\\Sigma)/D}`` where
-``\\Sigma = `` `covariance_matrix(sys)` is the SDE's noise rate matrix and `D` its
-state-space dimension.
+Effective noise strength ``\\sigma_{\\mathrm{eff}} = \\sqrt{\\mathrm{tr}(\\mathbf{\\Sigma})/D}``
+of `sys`, where ``\\mathbf{\\Sigma} = `` `covariance_matrix(sys)` and ``D = `` `dimension(sys)`.
+Together with [`normalize_covariance!`](@ref) it satisfies
+``\\sigma_{\\mathrm{eff}}^2 \\cdot \\mathbf{Q}_{\\mathrm{can}} = \\mathbf{\\Sigma}``.
 
-This is the σ produced by the trace-normalization convention used in the large-deviation
-action functionals (see [`fw_action`](@ref)): the SDE
-``\\mathrm{d}x = b\\,\\mathrm{d}t + \\sigma\\,\\Sigma_0\\,\\mathrm{d}W`` is canonicalized as
-``\\sigma_{\\mathrm{eff}}^2 = \\mathrm{tr}(\\sigma^2\\,Q)/D`` with
-``Q = \\Sigma_0\\Sigma_0^\\top``. For an SDE constructed with isotropic `covariance = I`,
-`noise_strength(sys)` recovers the `noise_strength` keyword passed at construction time.
-More generally, the returned value is the per-direction average of the noise variance.
+For an SDE built as ``\\mathrm{d}\\mathbf{x} = \\mathbf{b}\\,\\mathrm{d}t + \\sigma\\sqrt{\\mathbf{Q}}\\,\\mathrm{d}\\mathbf{W}``:
 
-For an SDE built with a custom `g` that is not of the form `σ * sqrt(Q)`, the returned
-value is still the trace-based effective σ of the resulting covariance matrix.
+  - **Isotropic `covariance = c·I`**: ``\\sigma_{\\mathrm{eff}} = \\sigma\\sqrt{c}``. The
+    default `covariance = I` (``c=1``) recovers the construction-time `noise_strength`
+    keyword exactly.
+  - **Anisotropic `Q`**: ``\\sigma_{\\mathrm{eff}} = \\sigma\\sqrt{\\mathrm{tr}(\\mathbf{Q})/D}``,
+    the per-direction average noise amplitude. Equals ``\\sigma`` whenever
+    ``\\mathrm{tr}(\\mathbf{Q}) = D``.
+  - **Custom `g`** (not of the form ``\\sigma\\sqrt{\\mathbf{Q}}``): still well-defined as the
+    trace-based effective σ of the resulting ``\\mathbf{\\Sigma}``.
+
+See [Large deviation theory](@ref) for the role of ``\\sigma_{\\mathrm{eff}}`` in the action
+functionals.
 """
 function noise_strength(sys::CoupledSDEs)
     Σ = covariance_matrix(sys)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -44,14 +44,22 @@ end;
 """
 $(TYPEDSIGNATURES)
 
-Normalizes the covariance matrix ``Q`` (in-place) by dividing it by
-``L_1(Q)/\\text{dim}(Q)``, where ``L_1(Q)`` is the L1 matrix norm of ``Q`` and
-``\\text{dim}(Q)`` is the dimension of ``Q``.
+Normalizes the covariance matrix ``Q`` so that its trace equals its dimension,
+``\\mathrm{tr}(Q) = D`` (equivalently, the average eigenvalue equals 1).
+
+This canonicalization breaks the ``(\\varepsilon, a_0) \\leftrightarrow (c\\varepsilon, a_0/c)``
+rescaling symmetry of the Freidlin-Wentzell action, so the action functional
+becomes a well-defined quantity for an SDE constructed from a `noise_strength` and a
+`covariance`. The result is independent of the noise strength chosen during
+construction, and (unlike L1-of-entries normalization) invariant under orthogonal
+changes of basis: ``\\mathrm{tr}(R\\,Q\\,R^\\top) = \\mathrm{tr}(Q)`` for any orthogonal `R`.
+
+For diagonal positive ``Q`` this coincides with dividing by `L_1(Q)/D`, so existing
+diagonal-noise call sites are numerically unchanged.
 """
 function normalize_covariance!(covariance)
-    l1norm = norm(covariance, 1)
-    dim = size(covariance)[1]
-    return covariance * dim / l1norm
+    D = size(covariance, 1)
+    return covariance * D / tr(covariance)
 end
 
 # Central finite difference, second derivative

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -44,18 +44,18 @@ end;
 """
 $(TYPEDSIGNATURES)
 
-Normalizes the covariance matrix ``Q`` so that its trace equals its dimension,
-``\\mathrm{tr}(Q) = D`` (equivalently, the average eigenvalue equals 1).
+Returns ``\\mathbf{Q}\\cdot D/\\mathrm{tr}(\\mathbf{Q})``, the trace-normalized covariance
+(``\\mathrm{tr} = D``, average eigenvalue 1).
 
-This canonicalization breaks the ``(\\varepsilon, a_0) \\leftrightarrow (c\\varepsilon, a_0/c)``
-rescaling symmetry of the Freidlin-Wentzell action, so the action functional
-becomes a well-defined quantity for an SDE constructed from a `noise_strength` and a
-`covariance`. The result is independent of the noise strength chosen during
-construction, and (unlike L1-of-entries normalization) invariant under orthogonal
-changes of basis: ``\\mathrm{tr}(R\\,Q\\,R^\\top) = \\mathrm{tr}(Q)`` for any orthogonal `R`.
+For an SDE built as ``\\mathrm{d}\\mathbf{x} = \\mathbf{b}\\,\\mathrm{d}t + \\sigma\\sqrt{\\mathbf{Q}}\\,\\mathrm{d}\\mathbf{W}``
+the SDE only fixes the product ``\\sigma^2\\mathbf{Q} = `` `covariance_matrix(sys)`; this
+function picks the canonical pair ``(\\sigma_{\\mathrm{eff}}, \\mathbf{Q}_{\\mathrm{can}})``
+defined by ``\\mathrm{tr}(\\mathbf{Q}_{\\mathrm{can}}) = D`` (see [`noise_strength`](@ref) for the
+matching ``\\sigma_{\\mathrm{eff}}``). Used internally by [`fw_action`](@ref),
+[`om_action`](@ref), and [`geometric_action`](@ref). For diagonal positive ``\\mathbf{Q}``
+this coincides numerically with dividing by ``L_1(\\mathbf{Q})/D``.
 
-For diagonal positive ``Q`` this coincides with dividing by `L_1(Q)/D`, so existing
-diagonal-noise call sites are numerically unchanged.
+See [Large deviation theory](@ref) for the rotation-invariance and conversion factors.
 """
 function normalize_covariance!(covariance)
     D = size(covariance, 1)

--- a/test/covariance.jl
+++ b/test/covariance.jl
@@ -75,3 +75,32 @@ end
     A = diffusion_matrix(ds)
     @test A * A' ≈ [1.0 0.5; 0.5 1.0]
 end
+
+@testset "noise_strength" begin
+    using StaticArrays, LinearAlgebra
+    f_ou(u, p, t) = -u
+
+    # Isotropic covariance: recovers the noise_strength keyword passed at construction.
+    sys_iso = CoupledSDEs(f_ou, SA[0.0, 0.0]; noise_strength = 0.3)
+    @test noise_strength(sys_iso) ≈ 0.3
+
+    # Anisotropic diagonal Q: returns the per-direction average noise std,
+    # i.e. σ · sqrt(tr(Q)/D).
+    sys_diag = CoupledSDEs(
+        f_ou, SA[0.0, 0.0]; covariance = [1.0 0.0; 0.0 4.0], noise_strength = 1.0
+    )
+    @test noise_strength(sys_diag) ≈ sqrt(5/2)
+
+    # Rotation invariance: the same physical SDE in a rotated basis returns
+    # the same effective noise strength.
+    R = [cos(π/4) -sin(π/4); sin(π/4) cos(π/4)]
+    Q_rot = R * [1.0 0.0; 0.0 4.0] * R'
+    sys_rot = CoupledSDEs(f_ou, SA[0.0, 0.0]; covariance = Q_rot, noise_strength = 1.0)
+    @test isapprox(noise_strength(sys_rot), noise_strength(sys_diag); rtol = 1.0e-12)
+
+    # Combined scaling: σ=0.5 with covariance=4I matches σ_eff = 0.5·sqrt(4) = 1.
+    sys_combined = CoupledSDEs(
+        f_ou, SA[0.0, 0.0]; covariance = [4.0 0.0; 0.0 4.0], noise_strength = 0.5
+    )
+    @test noise_strength(sys_combined) ≈ 1.0
+end

--- a/test/covariance.jl
+++ b/test/covariance.jl
@@ -89,11 +89,11 @@ end
     sys_diag = CoupledSDEs(
         f_ou, SA[0.0, 0.0]; covariance = [1.0 0.0; 0.0 4.0], noise_strength = 1.0
     )
-    @test noise_strength(sys_diag) ≈ sqrt(5/2)
+    @test noise_strength(sys_diag) ≈ sqrt(5 / 2)
 
     # Rotation invariance: the same physical SDE in a rotated basis returns
     # the same effective noise strength.
-    R = [cos(π/4) -sin(π/4); sin(π/4) cos(π/4)]
+    R = [cos(π / 4) -sin(π / 4); sin(π / 4) cos(π / 4)]
     Q_rot = R * [1.0 0.0; 0.0 4.0] * R'
     sys_rot = CoupledSDEs(f_ou, SA[0.0, 0.0]; covariance = Q_rot, noise_strength = 1.0)
     @test isapprox(noise_strength(sys_rot), noise_strength(sys_diag); rtol = 1.0e-12)

--- a/test/largedeviations/action_canonicalization.jl
+++ b/test/largedeviations/action_canonicalization.jl
@@ -15,7 +15,7 @@ using LinearAlgebra: tr
     sys_diag = CoupledSDEs(ou, SA[0.0, 0.0]; covariance = Q_diag, noise_strength = 1.0)
 
     # 45-degree rotation
-    R = [cos(π/4) -sin(π/4); sin(π/4) cos(π/4)]
+    R = [cos(π / 4) -sin(π / 4); sin(π / 4) cos(π / 4)]
     Q_rot = R * Q_diag * R'
     sys_rot = CoupledSDEs(ou, SA[0.0, 0.0]; covariance = Q_rot, noise_strength = 1.0)
 
@@ -23,7 +23,7 @@ using LinearAlgebra: tr
     time_arr = range(0.0, 1.0; length = N)
     path_orig = zeros(2, N)
     for (i, t) in enumerate(time_arr)
-        path_orig[:, i] = [1.0 + t, 0.5 + 0.3*sin(2π*t)]
+        path_orig[:, i] = [1.0 + t, 0.5 + 0.3 * sin(2π * t)]
     end
     path_rot = R * path_orig
 
@@ -32,12 +32,12 @@ using LinearAlgebra: tr
     # L1-of-entries normalization, these differed by tr(Q)/||Q||_1 across bases.
     @test isapprox(
         fw_action(sys_diag, path_orig, time_arr),
-        fw_action(sys_rot,  path_rot,  time_arr);
+        fw_action(sys_rot, path_rot, time_arr);
         rtol = 1.0e-10,
     )
     @test isapprox(
         geometric_action(sys_diag, path_orig),
-        geometric_action(sys_rot,  path_rot);
+        geometric_action(sys_rot, path_rot);
         rtol = 1.0e-10,
     )
 end
@@ -53,7 +53,7 @@ end
     time_arr = range(0.0, 1.0; length = N)
     path = zeros(2, N)
     for (i, t) in enumerate(time_arr)
-        path[:, i] = [1.0 + t, 0.5 + 0.3*sin(2π*t)]
+        path[:, i] = [1.0 + t, 0.5 + 0.3 * sin(2π * t)]
     end
 
     @test isapprox(
@@ -80,7 +80,7 @@ end
     path = reshape([x_T * sinh(t) / sinh(T) for t in time_arr], 1, :)
 
     S_action = fw_action(sys, path, time_arr)
-    S_expected = x_T^2 / (1 - exp(-2*T))
+    S_expected = x_T^2 / (1 - exp(-2 * T))
     @test isapprox(S_action, S_expected; rtol = 1.0e-4)
 
     # σ-independence sanity check

--- a/test/largedeviations/action_canonicalization.jl
+++ b/test/largedeviations/action_canonicalization.jl
@@ -1,0 +1,89 @@
+using Test
+using CriticalTransitions
+using StaticArrays
+using LinearAlgebra: tr
+
+# Verifies the FW convention adopted by the package:
+# `Q` is canonicalized to `tr(Q) = D`, so the action is independent of
+# `noise_strength` and invariant under orthogonal changes of basis. See the
+# docstring of `fw_action` for the underlying derivation.
+
+@testset "Rotation invariance with non-diagonal Q" begin
+    ou(u, p, t) = -u
+
+    Q_diag = [1.0 0.0; 0.0 4.0]
+    sys_diag = CoupledSDEs(ou, SA[0.0, 0.0]; covariance = Q_diag, noise_strength = 1.0)
+
+    # 45-degree rotation
+    R = [cos(π/4) -sin(π/4); sin(π/4) cos(π/4)]
+    Q_rot = R * Q_diag * R'
+    sys_rot = CoupledSDEs(ou, SA[0.0, 0.0]; covariance = Q_rot, noise_strength = 1.0)
+
+    N = 201
+    time_arr = range(0.0, 1.0; length = N)
+    path_orig = zeros(2, N)
+    for (i, t) in enumerate(time_arr)
+        path_orig[:, i] = [1.0 + t, 0.5 + 0.3*sin(2π*t)]
+    end
+    path_rot = R * path_orig
+
+    # The FW action is a coordinate-independent geometric quantity, so the same
+    # physical SDE/path in two bases must give the same number. With the previous
+    # L1-of-entries normalization, these differed by tr(Q)/||Q||_1 across bases.
+    @test isapprox(
+        fw_action(sys_diag, path_orig, time_arr),
+        fw_action(sys_rot,  path_rot,  time_arr);
+        rtol = 1.0e-10,
+    )
+    @test isapprox(
+        geometric_action(sys_diag, path_orig),
+        geometric_action(sys_rot,  path_rot);
+        rtol = 1.0e-10,
+    )
+end
+
+@testset "Action is independent of noise_strength" begin
+    ou(u, p, t) = -u
+
+    Q = [1.0 0.0; 0.0 4.0]
+    sys_a = CoupledSDEs(ou, SA[0.0, 0.0]; covariance = Q, noise_strength = 0.3)
+    sys_b = CoupledSDEs(ou, SA[0.0, 0.0]; covariance = Q, noise_strength = 2.5)
+
+    N = 201
+    time_arr = range(0.0, 1.0; length = N)
+    path = zeros(2, N)
+    for (i, t) in enumerate(time_arr)
+        path[:, i] = [1.0 + t, 0.5 + 0.3*sin(2π*t)]
+    end
+
+    @test isapprox(
+        fw_action(sys_a, path, time_arr),
+        fw_action(sys_b, path, time_arr);
+        rtol = 1.0e-12,
+    )
+end
+
+@testset "1D Ornstein-Uhlenbeck: action matches closed-form Φ_FW" begin
+    # dx = -x dt + σ dW. Closed-form minimum action from 0 to x_T over time T:
+    #   S_min(T) = x_T^2 / (1 - exp(-2T)) →  x_T^2  as T → ∞.
+    # In 1D the trace-normalized covariance is always 1, so the returned action
+    # is the σ-independent rate function `Φ_FW = x_T^2` (in the T → ∞ limit).
+    σ = 0.5
+    ou_1d(u, p, t) = SA[-u[1]]
+    sys = CoupledSDEs(ou_1d, SA[0.0]; noise_strength = σ)
+
+    x_T = 2.0
+    T = 10.0
+    N = 2001
+    time_arr = range(0.0, T; length = N)
+    # Instanton: φ(t) = x_T·sinh(t)/sinh(T) (solves ϕ̈ - ϕ = 0, BCs ϕ(0)=0, ϕ(T)=x_T)
+    path = reshape([x_T * sinh(t) / sinh(T) for t in time_arr], 1, :)
+
+    S_action = fw_action(sys, path, time_arr)
+    S_expected = x_T^2 / (1 - exp(-2*T))
+    @test isapprox(S_action, S_expected; rtol = 1.0e-4)
+
+    # σ-independence sanity check
+    sys2 = CoupledSDEs(ou_1d, SA[0.0]; noise_strength = 2.0)
+    @test isapprox(fw_action(sys2, path, time_arr), S_action; rtol = 1.0e-12)
+end

--- a/test/largedeviations/action_fhn.jl
+++ b/test/largedeviations/action_fhn.jl
@@ -23,7 +23,7 @@ end
 # Test om_action function
 @testset "om_action" begin
     S = om_action(sys, path, time, σ)
-    @test isapprox(S, 0.26, atol = 0.01)
+    @test isapprox(S, 0.21, atol = 0.01)
 end
 
 # Test action function

--- a/test/largedeviations/sgMAM.jl
+++ b/test/largedeviations/sgMAM.jl
@@ -187,6 +187,37 @@ end
     @test res_bt.action <= res_no_bt.action + 1.0e-6
 end
 
+@testset "sgMAM action matches geometric_action on converged path" begin
+    # Regression guard for the spurious /2 in `FW_action`: once converged, the
+    # path-action reported by sgMAM and the geometric action evaluated on the
+    # same path must agree (both are S_FW on the instanton). Before the fix,
+    # sgMAM reported half the geometric action.
+    function meier_stein(u, p, t)
+        x, y = u
+        dx = x - x^3 - 10 * x * y^2
+        dy = -(1 + x^2) * y
+        return SA[dx, dy]
+    end
+    σ = 0.25
+    ds = CoupledSDEs(meier_stein, zeros(2); noise_strength = σ)
+    sys = ExtendedPhaseSpace(ds)
+
+    xx = range(-1.0, 1.0; length = 60)
+    yy = 0.3 .* (-xx .^ 2 .+ 1)
+    x_initial = Matrix([xx yy]')
+
+    res = minimize_simple_geometric_action(
+        sys,
+        x_initial,
+        GeometricGradient(; max_backtracks = 20, stepsize = 1.0);
+        maxiters = 500,
+        show_progress = false,
+    )
+
+    S_geo = geometric_action(ds, Matrix(res.path)', 1.0)
+    @test isapprox(res.action, S_geo; rtol = 1.0e-3)
+end
+
 @testset "sgMAM step-size insensitivity" begin
     function meier_stein(u, p, t)
         x, y = u

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ end
 
 @testset "Large Deviations" begin
     include("largedeviations/action_fhn.jl")
+    include("largedeviations/action_canonicalization.jl")
     include("largedeviations/action_limit_cycle.jl")
     include("largedeviations/MAM.jl")
     include("largedeviations/gMAM.jl")


### PR DESCRIPTION
resolves #282

- Fix the spurious `/2` in sgMAM's `FW_action`. `minimize_simple_geometric_action(...).action` now equals `geometric_action(sys, MLP)` on the converged path, as it should.
- Fix a double-applied `/2` in `om_action` on the divergence-of-drift term.
- Switch `normalize_covariance!` from "L1-of-entries = D" to "trace = D". The new convention is rotation-invariant: the same physical SDE in different orthogonal bases now gives the same action. For diagonal positive `Q` the two conventions coincide, so existing diagonal-noise users (i.e. all current tests and sgMAM use cases) see no numerical change.
- Under the new convention `fw_action == Φ_FW` exactly for the canonicalized covariance. Users who pass a non-canonical `Q_user` recover their `Φ_FW` by multiplying by `tr(Q_user)/D` (documented in the `fw_action` docstring).
