### PR TITLE
feat: degenerate noise OLIM (rank-1 diffusion)

### DIFF
--- a/src/largedeviations/quasipotential/lagrangian.jl
+++ b/src/largedeviations/quasipotential/lagrangian.jl
@@ -170,6 +170,12 @@ return `SVector{D, T}` regardless of `IIP`. The trace-normalized diffusion is cl
 by `_degenerate_split`: full rank builds a `_GeometricLagrangian` directly; a single
 noiseless coordinate is regularized (`a + regularization * e_z e_z'`, leaving the noisy
 block exact) and then builds a `_GeometricLagrangian`; unsupported degeneracy throws.
+
+The degeneracy structure is classified once at `current_state(sys)` and assumed constant
+over the domain. For multiplicative noise the regularized coordinate `z` is fixed from
+that single sample; the rank-1 use cases (e.g. momentum-only noise) have a constant null
+coordinate, so this holds, but a diffusion whose null coordinate moves with `x` is not
+detected here.
 """
 function _geometric_lagrangian(
         sys::CoupledSDEs{IIP, D}, ::Type{T};

--- a/src/largedeviations/quasipotential/lagrangian.jl
+++ b/src/largedeviations/quasipotential/lagrangian.jl
@@ -45,6 +45,46 @@ interior root.
     return ((aₖ + bₖ) / 2, true)
 end
 
+const _OLIM_MULTI_NOISELESS_MSG =
+    "OLIM supports at most one noiseless coordinate (|Z| = 1). This diffusion has " *
+    "two or more zero coordinates (a sub-Riemannian problem), which is not supported. " *
+    _RANK_DEFICIENT_MSG
+
+const _OLIM_ROTATED_NULL_MSG =
+    "OLIM requires either an invertible diffusion or a single coordinate-aligned " *
+    "noiseless coordinate. This diffusion is singular with a non-coordinate-aligned " *
+    "null space, which is not supported. " * _RANK_DEFICIENT_MSG
+
+"""
+    _degenerate_split(a0; atol) -> (is_degenerate, z, R_idx)
+
+Classify the trace-normalized diffusion `a0`. Returns `(false, 0, 1:D)` for full rank,
+`(true, z, R_idx)` when exactly one coordinate `z` is noiseless (its row and column are
+numerically zero) and the remaining block `a0[R, R]` is positive-definite. Throws for two
+or more noiseless coordinates or a singular `a0` with a non-coordinate-aligned null space.
+"""
+function _degenerate_split(a0::AbstractMatrix{T}; atol::T = sqrt(eps(real(T)))) where {T}
+    D = LinearAlgebra.checksquare(a0)
+    is_zero_rowcol(i) = all(j -> abs(a0[i, j]) <= atol, 1:D) &&
+        all(j -> abs(a0[j, i]) <= atol, 1:D)
+    Z = findall(is_zero_rowcol, 1:D)
+    if isempty(Z)
+        if LinearAlgebra.cond(Matrix(a0)) > 1 / sqrt(eps(real(T)))
+            throw(ArgumentError(_OLIM_ROTATED_NULL_MSG))
+        end
+        return (false, 0, SVector{D, Int}(ntuple(identity, D)))
+    elseif length(Z) == 1
+        z = Z[1]
+        Ridx = SVector{D - 1, Int}(ntuple(k -> k < z ? k : k + 1, D - 1))
+        A_RR = Matrix(a0[Ridx, Ridx])
+        LinearAlgebra.isposdef(LinearAlgebra.Symmetric(A_RR)) ||
+            throw(ArgumentError(_OLIM_ROTATED_NULL_MSG))
+        return (true, z, Ridx)
+    else
+        throw(ArgumentError(_OLIM_MULTI_NOISELESS_MSG))
+    end
+end
+
 """
 Internal wrapper bundling drift, trace-normalized inverse metric, and the
 near-zero-drift threshold for `L_g(x, v) = |v|_Q |b|_Q - <v, b>_Q`.
@@ -104,15 +144,36 @@ end
 _make_Q_inv(a_fn, ::Val{D}, ::Type{T}) where {D, T} =
     _QInvDynamic{D, T, typeof(a_fn)}(a_fn)
 
+@inline _onehot_diag(::Val{D}, z::Int, ::Type{T}) where {D, T} =
+    SMatrix{D, D, T}(LinearAlgebra.Diagonal(SVector{D, T}(ntuple(i -> T(i == z), D))))
+
+# Multiplicative-noise inverse metric with the noiseless coordinate `z` regularized by
+# `delta`, so the otherwise-singular trace-normalized diffusion is invertible. The
+# `delta * e_z e_z'` regularizer is constant, so it is precomputed once into `reg`.
+struct _QInvRegDynamic{D, T, F, L}
+    a_fn::F
+    reg::SMatrix{D, D, T, L}
+end
+@inline function (q::_QInvRegDynamic{D, T})(x::SVector{D}) where {D, T}
+    a = SMatrix{D, D, T}(q.a_fn(x))
+    return inv(a + q.reg)
+end
+_make_Q_inv_reg(a_fn, z::Int, delta::T, ::Val{D}, ::Type{T}) where {D, T} =
+    _QInvRegDynamic{D, T, typeof(a_fn), D * D}(a_fn, delta * _onehot_diag(Val(D), z, T))
+
+# Diffusion tensor `a(x)` for the analytic CARE seed: invert the stored `Q_inv`.
+@inline _diffusion_at(L::_GeometricLagrangian, x) = inv(_Q_inv_at(L.Q_inv, x))
+
 """
-Build a `_GeometricLagrangian` from `sys`. Drift via `dynamic_rule(sys)`,
-wrapped to return `SVector{D, T}` regardless of `IIP`. `Q_inv` via
-`_trace_normalized_a(sys)`, inverted to an `SMatrix` (additive) or wrapped
-as `x -> inv(SMatrix(...))` (multiplicative).
+Build the per-segment Lagrangian from `sys`. Drift via `dynamic_rule(sys)`, wrapped to
+return `SVector{D, T}` regardless of `IIP`. The trace-normalized diffusion is classified
+by `_degenerate_split`: full rank builds a `_GeometricLagrangian` directly; a single
+noiseless coordinate is regularized (`a + regularization * e_z e_z'`, leaving the noisy
+block exact) and then builds a `_GeometricLagrangian`; unsupported degeneracy throws.
 """
 function _geometric_lagrangian(
         sys::CoupledSDEs{IIP, D}, ::Type{T};
-        eps_b::T = T(1.0e-10),
+        eps_b::T = T(1.0e-10), regularization::Real = zero(T),
     ) where {IIP, D, T}
     raw = dynamic_rule(sys); p = current_parameters(sys)
     b = if IIP
@@ -121,11 +182,21 @@ function _geometric_lagrangian(
         _make_b_oop(raw, p, Val(D))
     end
     a_fn = _trace_normalized_a(sys)
-    Q_inv = if a_fn isa Base.Returns
-        inv(SMatrix{D, D, T}(a_fn(current_state(sys))))
-    else
-        _make_Q_inv(a_fn, Val(D), T)
+    a0 = SMatrix{D, D, T}(a_fn(current_state(sys)))
+    is_deg, z, _ = _degenerate_split(a0)
+    if !is_deg
+        Q_inv = a_fn isa Base.Returns ? inv(a0) : _make_Q_inv(a_fn, Val(D), T)
+        return _GeometricLagrangian{D, T}(b, Q_inv, eps_b)
     end
+    δ = T(regularization)
+    δ > zero(T) || throw(
+        ArgumentError(
+            "rank-1 diffusion needs regularization > 0 to invert the metric; got $δ",
+        ),
+    )
+    Q_inv = a_fn isa Base.Returns ?
+        inv(a0 + δ * _onehot_diag(Val(D), z, T)) :
+        _make_Q_inv_reg(a_fn, z, δ, Val(D), T)
     return _GeometricLagrangian{D, T}(b, Q_inv, eps_b)
 end
 

--- a/src/largedeviations/quasipotential/lagrangian.jl
+++ b/src/largedeviations/quasipotential/lagrangian.jl
@@ -213,6 +213,31 @@ end
     return sqrt_vQv * sqrt(bnQ2) - dot(Qv, bx)
 end
 
+# Precomputed drift data at a cell center: `b = b(c)`, `q = |b|²_Q`, `sq = |b|_Q`.
+# Lets the additive line integral reuse the s=0/s=1 Simpson nodes that always land
+# on a cell center, skipping a drift eval, a matvec, and a sqrt per cached node.
+struct _NodeData{D, T}
+    b::SVector{D, T}
+    q::T
+    sq::T
+end
+
+@inline function _Lg_cached(
+        eps_b::T, nd::_NodeData{D, T},
+        Qv::SVector{D}, vQv::S, sqrt_vQv::S,
+    ) where {D, T, S}
+    if nd.q < S(eps_b) * S(eps_b)
+        return S(0.5) * vQv - dot(Qv, nd.b)
+    end
+    return sqrt_vQv * nd.sq - dot(Qv, nd.b)
+end
+
+# A Simpson node is either cached (`_NodeData`) or evaluated live (`nothing`).
+@inline _node_Lg(L::_GeometricLagrangian, x, ::Nothing, Qinv, Qv, vQv, sqrt_vQv) =
+    _Lg_at(L, x, Qinv, Qv, vQv, sqrt_vQv)
+@inline _node_Lg(L::_GeometricLagrangian, _x, nd::_NodeData, _Qinv, Qv, vQv, sqrt_vQv) =
+    _Lg_cached(L.eps_b, nd, Qv, vQv, sqrt_vQv)
+
 # Additive noise: Qinv is a constant SMatrix; hoist Qv, vQv, sqrt(vQv) out
 # of the three Simpson evaluations.
 @inline function _line_integral(
@@ -237,6 +262,29 @@ end
     half = S(0.5)
     return (L(y, v) + S(4) * L(y + half * v, v) + L(y + v, v)) / S(6)
 end
+
+# Additive noise with cached endpoint nodes. `nd0`/`nd1` are the s=0/s=1 Simpson
+# nodes: a `_NodeData` (cell-center lookup) or `nothing` (evaluate live). The
+# midpoint is always live. Bitwise-identical to the uncached path.
+@inline function _line_integral(
+        L::_GeometricLagrangian{D, T, B, A},
+        y::SVector{D, S}, v::SVector{D, S}, nd0, nd1,
+    ) where {D, T, B, A <: SMatrix, S}
+    half = S(0.5)
+    Qinv = L.Q_inv
+    Qv = Qinv * v
+    vQv = dot(v, Qv)
+    sv = sqrt(vQv)
+    L0 = _node_Lg(L, y, nd0, Qinv, Qv, vQv, sv)
+    Lh = _node_Lg(L, y + half * v, nothing, Qinv, Qv, vQv, sv)
+    L1 = _node_Lg(L, y + v, nd1, Qinv, Qv, vQv, sv)
+    return (L0 + S(4) * Lh + L1) / S(6)
+end
+
+# Multiplicative noise has no constant metric to cache against; ignore the nodes.
+@inline _line_integral(
+    L::_GeometricLagrangian{D, T}, y::SVector{D, S}, v::SVector{D, S}, _nd0, _nd1,
+) where {D, T, S} = _line_integral(L, y, v)
 
 @inline function _hermite_U(U0::T, U1::T, m0::T, m1::T, λ::T) where {T}
     s0 = isnan(m0) ? (U1 - U0) : m0

--- a/src/largedeviations/quasipotential/quasipotential.jl
+++ b/src/largedeviations/quasipotential/quasipotential.jl
@@ -62,11 +62,17 @@ dimension `D` is taken from `sys::CoupledSDEs{IIP, D, I, P}` and must match
 * `band_radius::Int  = default_K(grid)`: accepted-band radius in grid cells.
 * `near_source_layers::Int = 3`: size of the analytic CARE seed box;
   `0` disables analytic seeding.
-* `regularization::Real = default_regularization(grid)`: for systems with one
-  noiseless coordinate (rank-1 diffusion), the amount added to that coordinate's
-  diagonal of the trace-normalized diffusion to make the metric invertible. Smaller
-  values are more accurate but stiffer; reduce it as the grid is refined. Ignored for
-  full-rank systems.
+* `regularization::Real = default_regularization(grid)`: for a system with a single
+  noiseless coordinate (rank-1 diffusion, e.g. momentum-only noise in a second-order
+  Langevin or van der Pol oscillator) the trace-normalized diffusion is singular and
+  has no metric. This amount is added to that coordinate's diagonal (a structural
+  vanishing-viscosity perturbation that leaves the noisy block exact) to make it
+  invertible; the degenerate Freidlin-Wentzell quasipotential is recovered as it tends
+  to 0. The default scales like `1 / minimum(grid.nbox)` (about `0.04` at 80 cells), so
+  it shrinks under refinement; smaller values are more accurate but stiffer. The escape
+  sheet and saddle barrier carry negligible bias, the non-escape region carries the
+  regularization bias. Ignored for full-rank systems; two or more noiseless coordinates
+  (sub-Riemannian) or a non-coordinate-aligned null space are rejected.
 * `verbose::Bool      = false`
 * `show_progress::Bool = true`
 

--- a/src/largedeviations/quasipotential/quasipotential.jl
+++ b/src/largedeviations/quasipotential/quasipotential.jl
@@ -111,8 +111,8 @@ function _quasipotential_impl(
         regularization::T, verbose::Bool, show_progress::Bool,
     ) where {IIP, D, I, P, T, K, K_seed}
     src = _source_cell(grid, x_A)
-    state = _OLIMState(grid, T)
     L = _geometric_lagrangian(sys, T; regularization = regularization)
+    state = _OLIMState(grid, T, L.Q_inv isa SMatrix)
     _sweep!(
         state, grid, src, sys, L, Val(K), Val(K_seed);
         verbose = verbose, show_progress = show_progress,

--- a/src/largedeviations/quasipotential/quasipotential.jl
+++ b/src/largedeviations/quasipotential/quasipotential.jl
@@ -17,6 +17,19 @@ Within these bounds the radius is `round(Int, sqrt(minimum(grid.nbox)))`.
     return clamp(round(Int, sqrt(minimum(grid.nbox))), floor_K, cap_K)
 end
 
+"""
+    default_regularization(grid::CartesianGrid) -> T
+
+Default regularization for rank-1 (single noiseless coordinate) diffusion: the amount
+added to the noiseless diagonal of the trace-normalized diffusion so the metric is
+invertible. Proportional to the noiseless cell fraction (`1 / minimum(grid.nbox)`) so it
+vanishes under refinement, with the constant calibrated to about `0.04` at `80` cells
+across. Ignored for full-rank systems; override with the `regularization` keyword of
+[`quasipotential`](@ref).
+"""
+@inline default_regularization(grid::CartesianGrid{D, T}) where {D, T} =
+    T(3.2) / minimum(grid.nbox)
+
 function _source_cell(
         grid::CartesianGrid{D, T}, attractor::SVector{D, T}
     ) where {D, T}
@@ -49,6 +62,11 @@ dimension `D` is taken from `sys::CoupledSDEs{IIP, D, I, P}` and must match
 * `band_radius::Int  = default_K(grid)`: accepted-band radius in grid cells.
 * `near_source_layers::Int = 3`: size of the analytic CARE seed box;
   `0` disables analytic seeding.
+* `regularization::Real = default_regularization(grid)`: for systems with one
+  noiseless coordinate (rank-1 diffusion), the amount added to that coordinate's
+  diagonal of the trace-normalized diffusion to make the metric invertible. Smaller
+  values are more accurate but stiffer; reduce it as the grid is refined. Ignored for
+  full-rank systems.
 * `verbose::Bool      = false`
 * `show_progress::Bool = true`
 
@@ -60,6 +78,7 @@ function quasipotential(
         attractor::AbstractVector{<:Real};
         band_radius::Int = default_K(grid),
         near_source_layers::Int = 3,
+        regularization::Real = default_regularization(grid),
         verbose::Bool = false,
         show_progress::Bool = true,
     ) where {IIP, D, I, P, T}
@@ -74,7 +93,7 @@ function quasipotential(
     return _quasipotential_impl(
         sys, grid, x_A,
         Val(band_radius), Val(near_source_layers),
-        verbose, show_progress,
+        T(regularization), verbose, show_progress,
     )
 end
 
@@ -83,11 +102,11 @@ function _quasipotential_impl(
         grid::CartesianGrid{D, T},
         x_A::SVector{D, T},
         ::Val{K}, ::Val{K_seed},
-        verbose::Bool, show_progress::Bool,
+        regularization::T, verbose::Bool, show_progress::Bool,
     ) where {IIP, D, I, P, T, K, K_seed}
     src = _source_cell(grid, x_A)
     state = _OLIMState(grid, T)
-    L = _geometric_lagrangian(sys, T)
+    L = _geometric_lagrangian(sys, T; regularization = regularization)
     _sweep!(
         state, grid, src, sys, L, Val(K), Val(K_seed);
         verbose = verbose, show_progress = show_progress,

--- a/src/largedeviations/quasipotential/state.jl
+++ b/src/largedeviations/quasipotential/state.jl
@@ -46,6 +46,12 @@ struct _OLIMState{D, T, H}
     heap::H
     handles::Vector{Int}
     nbox::NTuple{D, Int}
+    # Per-cell drift cache for the additive-noise line integral: `b_c[I] = b(c_I)`,
+    # `q_c[I] = |b(c_I)|²_Q`, `sq_c[I] = |b(c_I)|_Q` at each cell center `c_I`.
+    # Populated once by `_fill_node_cache!`; left zero (unused) for multiplicative noise.
+    b_c::Array{SVector{D, T}, D}
+    q_c::Array{T, D}
+    sq_c::Array{T, D}
 end
 
 function _OLIMState(grid::CartesianGrid{D, T}, ::Type{T}) where {D, T}
@@ -60,7 +66,12 @@ function _OLIMState(grid::CartesianGrid{D, T}, ::Type{T}) where {D, T}
     sizehint!(heap.nodes, prod(nbox))
     sizehint!(heap.node_map, prod(nbox))
     handles = zeros(Int, prod(nbox))
-    return _OLIMState{D, T, typeof(heap)}(U, bp, status, front, heap, handles, nbox)
+    b_c = fill(zero(SVector{D, T}), nbox)
+    q_c = zeros(T, nbox)
+    sq_c = zeros(T, nbox)
+    return _OLIMState{D, T, typeof(heap)}(
+        U, bp, status, front, heap, handles, nbox, b_c, q_c, sq_c,
+    )
 end
 
 @inline _linear(x::CartesianIndex{D}, nbox::NTuple{D, Int}) where {D} =

--- a/src/largedeviations/quasipotential/state.jl
+++ b/src/largedeviations/quasipotential/state.jl
@@ -48,13 +48,19 @@ struct _OLIMState{D, T, H}
     nbox::NTuple{D, Int}
     # Per-cell drift cache for the additive-noise line integral: `b_c[I] = b(c_I)`,
     # `q_c[I] = |b(c_I)|²_Q`, `sq_c[I] = |b(c_I)|_Q` at each cell center `c_I`.
-    # Populated once by `_fill_node_cache!`; left zero (unused) for multiplicative noise.
+    # Populated once by `_fill_node_cache!` (additive noise only). For multiplicative
+    # noise the metric is not constant, so these are allocated empty (zero-size,
+    # never indexed) to avoid a full-grid allocation that would never be read.
     b_c::Array{SVector{D, T}, D}
     q_c::Array{T, D}
     sq_c::Array{T, D}
 end
 
-function _OLIMState(grid::CartesianGrid{D, T}, ::Type{T}) where {D, T}
+# `cache_drift` allocates the full-grid additive-noise drift cache; pass `false`
+# for multiplicative noise to allocate empty placeholders (see `_fill_node_cache!`).
+function _OLIMState(
+        grid::CartesianGrid{D, T}, ::Type{T}, cache_drift::Bool = true,
+    ) where {D, T}
     nbox = grid.nbox
     U = fill(T(Inf), nbox)
     bp = fill(BackRef{D}(), nbox)
@@ -66,9 +72,10 @@ function _OLIMState(grid::CartesianGrid{D, T}, ::Type{T}) where {D, T}
     sizehint!(heap.nodes, prod(nbox))
     sizehint!(heap.node_map, prod(nbox))
     handles = zeros(Int, prod(nbox))
-    b_c = fill(zero(SVector{D, T}), nbox)
-    q_c = zeros(T, nbox)
-    sq_c = zeros(T, nbox)
+    cbox = cache_drift ? nbox : ntuple(_ -> 0, Val(D))
+    b_c = fill(zero(SVector{D, T}), cbox)
+    q_c = zeros(T, cbox)
+    sq_c = zeros(T, cbox)
     return _OLIMState{D, T, typeof(heap)}(
         U, bp, status, front, heap, handles, nbox, b_c, q_c, sq_c,
     )

--- a/src/largedeviations/quasipotential/stencil.jl
+++ b/src/largedeviations/quasipotential/stencil.jl
@@ -1,14 +1,17 @@
+# Circular-stencil offsets, sorted by squared radius. Returned as a `const` `Vector`
+# (built once per `(K, D)`): iterating the cached vector is linear, whereas the old
+# tuple form hit Julia's large-tuple iteration cliff for the wide stencils that
+# anisotropic problems require (e.g. K=12 -> a ~450-element tuple).
 @generated function _stencil_offsets(::Val{K}, ::Val{D}) where {K, D}
-    offsets = NTuple{D, Int}[]
+    offsets = CartesianIndex{D}[]
     box = ntuple(_ -> -K:K, D)
     for I in Iterators.product(box...)
         all(==(0), I) && continue
         sum(abs2, I) <= K * K || continue
-        push!(offsets, I)
+        push!(offsets, CartesianIndex(I))
     end
-    sort!(offsets; by = t -> sum(abs2, t))
-    cis = [:(CartesianIndex($(t...))) for t in offsets]
-    return Expr(:tuple, cis...)
+    sort!(offsets; by = t -> sum(abs2, Tuple(t)))
+    return :($offsets)
 end
 
 @inline function _shift_in_bounds(

--- a/src/largedeviations/quasipotential/stencil.jl
+++ b/src/largedeviations/quasipotential/stencil.jl
@@ -1,7 +1,9 @@
 # Circular-stencil offsets, sorted by squared radius. Returned as a `const` `Vector`
 # (built once per `(K, D)`): iterating the cached vector is linear, whereas the old
 # tuple form hit Julia's large-tuple iteration cliff for the wide stencils that
-# anisotropic problems require (e.g. K=12 -> a ~450-element tuple).
+# anisotropic problems require (e.g. K=12 -> a ~450-element tuple). The same vector
+# instance is shared across all calls with the same `(K, D)`; callers iterate it
+# read-only and must never mutate it.
 @generated function _stencil_offsets(::Val{K}, ::Val{D}) where {K, D}
     offsets = CartesianIndex{D}[]
     box = ntuple(_ -> -K:K, D)

--- a/src/largedeviations/quasipotential/sweep.jl
+++ b/src/largedeviations/quasipotential/sweep.jl
@@ -43,7 +43,7 @@ function _seed_near_source!(
             @info "OLIM: attractor cell is not strictly stable; analytic seed skipped"
         return state
     end
-    Q_mat = L.Q_inv isa SMatrix ? inv(L.Q_inv) : inv(L.Q_inv(x_A))
+    Q_mat = _diffusion_at(L, x_A)
     P = try
         _care(Matrix(A_jac), Matrix(Q_mat))
     catch err

--- a/src/largedeviations/quasipotential/sweep.jl
+++ b/src/largedeviations/quasipotential/sweep.jl
@@ -84,6 +84,7 @@ function _sweep!(
         ::Val{K}, ::Val{K_seed};
         verbose::Bool, show_progress::Bool,
     ) where {D, T, K, K_seed}
+    _fill_node_cache!(state, grid, L)
     _seed_near_source!(state, grid, source, sys, L, Val(K_seed); verbose = verbose)
 
     nbox = state.nbox

--- a/src/largedeviations/quasipotential/update.jl
+++ b/src/largedeviations/quasipotential/update.jl
@@ -1,31 +1,64 @@
+# Per-cell drift cache (additive noise only): one drift eval per cell up front
+# replaces the thousands of redundant cell-center evals across the sweep.
+@inline function _fill_node_cache!(
+        state::_OLIMState{D, T}, grid::CartesianGrid{D, T},
+        L::_GeometricLagrangian{D, T, B, A},
+    ) where {D, T, B, A <: SMatrix}
+    Qinv = L.Q_inv
+    @inbounds for I in CartesianIndices(state.U)
+        b = L.b(cell_center(grid, I))
+        q = dot(b, Qinv * b)
+        state.b_c[I] = b
+        state.q_c[I] = q
+        state.sq_c[I] = sqrt(q)
+    end
+    return state
+end
+@inline _fill_node_cache!(
+    state::_OLIMState{D, T}, ::CartesianGrid{D, T}, ::_GeometricLagrangian{D, T},
+) where {D, T} = state
+
+# Cached drift data at cell `I` (additive noise) or `nothing` (multiplicative).
+@inline function _node_at(
+        state::_OLIMState{D, T}, I::CartesianIndex{D},
+        ::_GeometricLagrangian{D, T, B, A},
+    ) where {D, T, B, A <: SMatrix}
+    @inbounds return _NodeData{D, T}(state.b_c[I], state.q_c[I], state.sq_c[I])
+end
+@inline _node_at(
+    ::_OLIMState{D, T}, ::CartesianIndex{D}, ::_GeometricLagrangian{D, T},
+) where {D, T} = nothing
+
 @inline function _vertex_candidate(
         c_x::SVector{D, T}, c_y::SVector{D, T},
-        U_y::T, L::_GeometricLagrangian{D, T},
+        U_y::T, L::_GeometricLagrangian{D, T}, nd_y, nd_x,
     ) where {D, T}
     v = c_x - c_y
-    return U_y + _line_integral(L, c_y, v)
+    return U_y + _line_integral(L, c_y, v, nd_y, nd_x)
 end
 
+# The interior point `y` is interpolated (never a cell center), so the s=0 node is
+# always live; only the shared s=1 node `c_x` is cached via `nd_x`.
 @inline function _edge_phi(
         c_x::SVector{D, T}, c_y0::SVector{D, T}, c_y1::SVector{D, T},
         U0::T, U1::T, m0::T, m1::T, λ::T,
-        L::_GeometricLagrangian{D, T},
+        L::_GeometricLagrangian{D, T}, nd_x,
     ) where {D, T}
     y = (one(T) - λ) * c_y0 + λ * c_y1
-    return _hermite_U(U0, U1, m0, m1, λ) + _line_integral(L, y, c_x - y)
+    return _hermite_U(U0, U1, m0, m1, λ) + _line_integral(L, y, c_x - y, nothing, nd_x)
 end
 
 @inline function _edge_dphi(
         c_x::SVector{D, T}, c_y0::SVector{D, T}, c_y1::SVector{D, T},
         U0::T, U1::T, m0::T, m1::T, λ::T,
-        L::_GeometricLagrangian{D, T},
+        L::_GeometricLagrangian{D, T}, nd_x,
     ) where {D, T}
     h = sqrt(eps(T))
     λp = clamp(λ + h, zero(T), one(T))
     λm = clamp(λ - h, zero(T), one(T))
     return (
-        _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, λp, L) -
-            _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, λm, L)
+        _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, λp, L, nd_x) -
+            _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, λm, L, nd_x)
     ) / (λp - λm)
 end
 
@@ -33,7 +66,7 @@ end
 Edge candidate minimum (§4.4). Evaluates Φ(0), Φ(1), and an ITP root of
 dΦ/dλ; the smallest wins. `λ* ∈ {0, 1}` indicates a boundary win.
 """
-struct _EdgeDPhi{D, T, LT}
+struct _EdgeDPhi{D, T, LT, NX}
     c_x::SVector{D, T}
     c_y0::SVector{D, T}
     c_y1::SVector{D, T}
@@ -42,28 +75,29 @@ struct _EdgeDPhi{D, T, LT}
     m0::T
     m1::T
     L::LT
+    nd_x::NX
 end
 @inline (g::_EdgeDPhi)(λ) =
-    _edge_dphi(g.c_x, g.c_y0, g.c_y1, g.U0, g.U1, g.m0, g.m1, λ, g.L)
+    _edge_dphi(g.c_x, g.c_y0, g.c_y1, g.U0, g.U1, g.m0, g.m1, λ, g.L, g.nd_x)
 
 @inline function _edge_minimum(
         c_x::SVector{D, T},
         c_y0::SVector{D, T}, c_y1::SVector{D, T},
         U0::T, U1::T, m0::T, m1::T,
-        L::_GeometricLagrangian{D, T},
+        L::_GeometricLagrangian{D, T}, nd_x,
         cutoff::T = T(Inf),
-        Φ0::T = _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, zero(T), L),
-        Φ1::T = _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, one(T), L),
+        Φ0::T = _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, zero(T), L, nd_x),
+        Φ1::T = _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, one(T), L, nd_x),
     ) where {D, T}
     best, λstar = (Φ0 <= Φ1) ? (Φ0, zero(T)) : (Φ1, one(T))
     # Skip ITP if both endpoints already exceed the caller's running best.
     # The interior could still be lower, but on Maupertuis-like problems the
     # interior minimum is bracketed by smaller endpoints in practice.
     (Φ0 > cutoff && Φ1 > cutoff) && return (best, λstar)
-    g = _EdgeDPhi(c_x, c_y0, c_y1, U0, U1, m0, m1, L)
+    g = _EdgeDPhi(c_x, c_y0, c_y1, U0, U1, m0, m1, L, nd_x)
     λroot, ok = itp_root(g, zero(T), one(T); atol = T(1.0e-4), maxiter = 20)
     if ok && zero(T) < λroot < one(T)
-        Φi = _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, λroot, L)
+        Φi = _edge_phi(c_x, c_y0, c_y1, U0, U1, m0, m1, λroot, L, nd_x)
         if Φi < best
             best, λstar = Φi, λroot
         end
@@ -94,42 +128,42 @@ then attempt an interior Newton step with FD gradient/Hessian.
         c_x::SVector{3, T},
         c_y0::SVector{3, T}, c_y1::SVector{3, T}, c_y2::SVector{3, T},
         U0::T, U1::T, U2::T,
-        L::_GeometricLagrangian{3, T}, λ1::T, λ2::T,
+        L::_GeometricLagrangian{3, T}, λ1::T, λ2::T, nd_x,
     ) where {T}
     y = (one(T) - λ1 - λ2) * c_y0 + λ1 * c_y1 + λ2 * c_y2
     return ((one(T) - λ1 - λ2) * U0 + λ1 * U1 + λ2 * U2) +
-        _line_integral(L, y, c_x - y)
+        _line_integral(L, y, c_x - y, nothing, nd_x)
 end
 
 @inline function _triangle_minimum(
         c_x::SVector{3, T},
         c_y0::SVector{3, T}, c_y1::SVector{3, T}, c_y2::SVector{3, T},
         U0::T, U1::T, U2::T,
-        L::_GeometricLagrangian{3, T},
+        L::_GeometricLagrangian{3, T}, nd_x,
     ) where {T}
-    Φ00 = _tri_phi(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, zero(T), zero(T))
+    Φ00 = _tri_phi(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, zero(T), zero(T), nd_x)
     best, bλ1, bλ2 = Φ00, zero(T), zero(T)
-    Φ1 = _tri_phi(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, one(T), zero(T))
+    Φ1 = _tri_phi(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, one(T), zero(T), nd_x)
     Φ1 < best && ((best, bλ1, bλ2) = (Φ1, one(T), zero(T)))
-    Φ2 = _tri_phi(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, zero(T), one(T))
+    Φ2 = _tri_phi(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, zero(T), one(T), nd_x)
     Φ2 < best && ((best, bλ1, bλ2) = (Φ2, zero(T), one(T)))
 
-    Φe01, λs01 = _edge_minimum(c_x, c_y0, c_y1, U0, U1, T(NaN), T(NaN), L)
+    Φe01, λs01 = _edge_minimum(c_x, c_y0, c_y1, U0, U1, T(NaN), T(NaN), L, nd_x)
     if Φe01 < best
         best = Φe01; bλ1 = λs01; bλ2 = zero(T)
     end
-    Φe02, λs02 = _edge_minimum(c_x, c_y0, c_y2, U0, U2, T(NaN), T(NaN), L)
+    Φe02, λs02 = _edge_minimum(c_x, c_y0, c_y2, U0, U2, T(NaN), T(NaN), L, nd_x)
     if Φe02 < best
         best = Φe02; bλ1 = zero(T); bλ2 = λs02
     end
-    Φe12, λs12 = _edge_minimum(c_x, c_y1, c_y2, U1, U2, T(NaN), T(NaN), L)
+    Φe12, λs12 = _edge_minimum(c_x, c_y1, c_y2, U1, U2, T(NaN), T(NaN), L, nd_x)
     if Φe12 < best
         best = Φe12; bλ1 = one(T) - λs12; bλ2 = λs12
     end
 
     h = sqrt(eps(T))
     λ1 = one(T) / 3; λ2 = one(T) / 3
-    @inline P(a, b) = _tri_phi(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, a, b)
+    @inline P(a, b) = _tri_phi(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, a, b, nd_x)
     for _ in 1:8
         gx = (P(λ1 + h, λ2) - P(λ1 - h, λ2)) / (2h)
         gy = (P(λ1, λ2 + h) - P(λ1, λ2 - h)) / (2h)
@@ -148,7 +182,7 @@ end
         (λ1 < 0 || λ2 < 0 || λ1 + λ2 > 1) && break
     end
     if λ1 > 0 && λ2 > 0 && λ1 + λ2 < 1
-        Φi = _tri_phi(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, λ1, λ2)
+        Φi = _tri_phi(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, λ1, λ2, nd_x)
         Φi < best && ((best, bλ1, bλ2) = (Φi, λ1, λ2))
     end
     return (best, bλ1, bλ2)
@@ -167,6 +201,7 @@ function _local_update(
     ) where {D, T, K}
     nbox = state.nbox
     c_x = cell_center(grid, x)
+    nd_x = _node_at(state, x, L)
     best = T(Inf)
     best_ref = BackRef{D}()
     offsets = _stencil_offsets(Val(K), Val(D))
@@ -179,7 +214,7 @@ function _local_update(
         U_y = state.U[y]
         (isfinite(U_y) && U_y < best) || continue
         c_y = cell_center(grid, y)
-        Φ = _vertex_candidate(c_x, c_y, U_y, L)
+        Φ = _vertex_candidate(c_x, c_y, U_y, L, _node_at(state, y, L), nd_x)
         if Φ < best
             best = Φ
             best_ref = BackRef{D}(y, y, NaN32)
@@ -205,6 +240,7 @@ function _add_simplex_candidates(
     ) where {T, K}
     nbox = state.nbox
     front = state.front
+    nd_x = _node_at(state, x, L)
     offsets = _stencil_offsets(Val(K), Val(2))
     cheb = _chebyshev_neighbors(Val(2))
     @inbounds for δ0 in offsets
@@ -215,10 +251,11 @@ function _add_simplex_candidates(
         isfinite(U0) || continue
         U0 < best || continue  # vertex bound Φ ≥ U0
         c_y0 = cell_center(grid, y0)
+        nd_y0 = _node_at(state, y0, L)
         # Φ0 = vertex candidate from y0 (same as edge Φ(λ=0)). Compute once,
         # reuse for the vertex update and as the Φ(0) endpoint of every edge
         # leaving y0.
-        Φ0 = U0 + _line_integral(L, c_y0, c_x - c_y0)
+        Φ0 = U0 + _line_integral(L, c_y0, c_x - c_y0, nd_y0, nd_x)
         if Φ0 < best
             best = Φ0
             best_ref = BackRef{2}(y0, y0, NaN32)
@@ -233,11 +270,11 @@ function _add_simplex_candidates(
             (isfinite(U1) && U1 < best) || continue
             c_y1 = cell_center(grid, y1)
             # Φ(1) is the vertex candidate from y1; cheap, gates ITP.
-            Φ1 = U1 + _line_integral(L, c_y1, c_x - c_y1)
+            Φ1 = U1 + _line_integral(L, c_y1, c_x - c_y1, _node_at(state, y1, L), nd_x)
             (min(Φ0, Φ1) < best) || continue
             m0, m1 = _edge_slope_estimates(state, y0, y1)
             Φ, λstar = _edge_minimum(
-                c_x, c_y0, c_y1, U0, U1, m0, m1, L, best, Φ0, Φ1,
+                c_x, c_y0, c_y1, U0, U1, m0, m1, L, nd_x, best, Φ0, Φ1,
             )
             if Φ < best
                 best = Φ
@@ -258,6 +295,7 @@ function _add_simplex_candidates(
     ) where {T, K}
     nbox = state.nbox
     front = state.front
+    nd_x = _node_at(state, x, L)
     offsets = _stencil_offsets(Val(K), Val(3))
     cheb = _chebyshev_neighbors(Val(3))
     @inbounds for δ0 in offsets
@@ -267,7 +305,7 @@ function _add_simplex_candidates(
         U0 = state.U[y0]
         isfinite(U0) || continue
         c_y0 = cell_center(grid, y0)
-        Φ0 = U0 + _line_integral(L, c_y0, c_x - c_y0)
+        Φ0 = U0 + _line_integral(L, c_y0, c_x - c_y0, _node_at(state, y0, L), nd_x)
         if Φ0 < best
             best = Φ0
             best_ref = BackRef{3}(y0, y0, NaN32)
@@ -291,7 +329,7 @@ function _add_simplex_candidates(
                 U2 = state.U[y2]
                 isfinite(U2) || continue
                 c_y2 = cell_center(grid, y2)
-                Φ, λ1, _ = _triangle_minimum(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L)
+                Φ, λ1, _ = _triangle_minimum(c_x, c_y0, c_y1, c_y2, U0, U1, U2, L, nd_x)
                 if Φ < best
                     best = Φ
                     best_ref = BackRef{3}(y0, y1, Float32(λ1))

--- a/test/largedeviations/quasipotential.jl
+++ b/test/largedeviations/quasipotential.jl
@@ -257,6 +257,25 @@ const CT_ = CriticalTransitions
         @test CT_._diffusion_at(Lf, SVector(0.0, 0.0)) ≈ SMatrix{2, 2, Float64}(I)
     end
 
+    @testset "cached line integral == live (additive)" begin
+        # The cached additive path must be bitwise-identical to the live path; this
+        # locks the equivalence the drift cache relies on.
+        b = x -> SVector(-x[1], x[1] - x[2])
+        Qinv = SMatrix{2, 2, Float64}(2.0, 0.3, 0.3, 1.5)   # symmetric PD
+        L = CT_._GeometricLagrangian{2, Float64}(b, Qinv, 1.0e-10)
+        nd(x) = (bb = b(x); q = dot(bb, Qinv * bb); CT_._NodeData{2, Float64}(bb, q, sqrt(q)))
+        y = SVector(0.2, -0.4); v = SVector(0.1, 0.25)
+        live = CT_._line_integral(L, y, v)
+        @test CT_._line_integral(L, y, v, nd(y), nd(y + v)) == live   # both endpoints cached
+        @test CT_._line_integral(L, y, v, nothing, nd(y + v)) == live # only s=1 cached (edge use)
+        @test CT_._line_integral(L, y, v, nd(y), nothing) == live     # only s=0 cached
+        # near-zero-drift branch (|b|²_Q < eps_b²) must also match
+        bz = x -> SVector(0.0, 0.0)
+        Lz = CT_._GeometricLagrangian{2, Float64}(bz, Qinv, 1.0e-10)
+        ndz = CT_._NodeData{2, Float64}(SVector(0.0, 0.0), 0.0, 0.0)
+        @test CT_._line_integral(Lz, y, v, ndz, ndz) == CT_._line_integral(Lz, y, v)
+    end
+
     @testset "default_regularization" begin
         g80 = CartesianGrid((-1.0, 1.0, 80), (-1.0, 1.0, 80))
         @test CT_.default_regularization(g80) ≈ 0.04
@@ -282,6 +301,15 @@ const CT_ = CriticalTransitions
         g3(u, p, t) = @SMatrix [0.0 0.0 0.0; 0.0 0.0 0.0; 0.0 0.0 1.0]
         sys3 = CoupledSDEs(drift3, SA[0.0, 0.0, 0.0]; g = g3, noise_prototype = SMatrix{3, 3}(zeros(3, 3)))
         @test_throws ArgumentError CT_._geometric_lagrangian(sys3, Float64; regularization = 0.04)
+
+        # state-dependent rank-1 noise -> dynamic regularized metric (_QInvRegDynamic),
+        # not the constant SMatrix branch. The regularized metric must be PD everywhere.
+        gmul(u, p, t) = @SMatrix [0.0 0.0; 0.0 sqrt(2.0) * (1.0 + 0.2 * u[1]^2)]
+        sysm = CoupledSDEs(drift, SA[0.0, 0.0]; g = gmul, noise_prototype = SMatrix{2, 2}(zeros(2, 2)))
+        Lm = CT_._geometric_lagrangian(sysm, Float64; regularization = 0.04)
+        @test !(Lm.Q_inv isa SMatrix)                                   # dynamic metric
+        @test all(isposdef(inv(Lm.Q_inv(SVector(x, p)))) for x in (-0.5, 0.0, 0.5), p in (-0.3, 0.3))
+        @test_throws ArgumentError CT_._geometric_lagrangian(sysm, Float64)  # needs reg
     end
 
     @testset "regularized OLIM: equilibrium Langevin" begin

--- a/test/largedeviations/quasipotential.jl
+++ b/test/largedeviations/quasipotential.jl
@@ -253,7 +253,7 @@ const CT_ = CriticalTransitions
     end
 
     @testset "diffusion accessor" begin
-        Lf = CT_._GeometricLagrangian{2, Float64}(x -> -x, SMatrix{2, 2, Float64}(I), 1e-10)
+        Lf = CT_._GeometricLagrangian{2, Float64}(x -> -x, SMatrix{2, 2, Float64}(I), 1.0e-10)
         @test CT_._diffusion_at(Lf, SVector(0.0, 0.0)) ≈ SMatrix{2, 2, Float64}(I)
     end
 
@@ -308,7 +308,7 @@ const CT_ = CriticalTransitions
         isad = argmin(abs.(xs)); jsad = argmin(abs.(ps))
         @test abs(qp.U[isad, jsad] - 0.25) <= 0.02               # saddle barrier
         @test qp.U[qp.source] == 0.0
-        @test all(>=(-1e-8), filter(isfinite, qp.U))
+        @test all(>=(-1.0e-8), filter(isfinite, qp.U))
     end
 
     @testset "regularized OLIM: van der Pol (non-equilibrium)" begin

--- a/test/largedeviations/quasipotential.jl
+++ b/test/largedeviations/quasipotential.jl
@@ -240,4 +240,91 @@ const CT_ = CriticalTransitions
         # should be reached by the sweep with U ≥ 0 throughout.
         @test all(>=(0), filter(isfinite, qp.U))
     end
+
+    @testset "degenerate split" begin
+        isdeg, _, _ = CT_._degenerate_split([1.0 0.0; 0.0 1.0])
+        @test !isdeg
+        isdeg, z, R = CT_._degenerate_split([0.0 0.0; 0.0 2.0])   # noise only in coord 2
+        @test isdeg && z == 1 && collect(R) == [2]
+        isdeg, z, R = CT_._degenerate_split([0.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 3.0])  # |Z|=1 in 3D
+        @test isdeg && z == 1 && collect(R) == [2, 3]
+        @test_throws ArgumentError CT_._degenerate_split([0.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 0.0])  # |Z|=2
+        @test_throws ArgumentError CT_._degenerate_split([1.0 1.0; 1.0 1.0])  # rotated singular
+    end
+
+    @testset "diffusion accessor" begin
+        Lf = CT_._GeometricLagrangian{2, Float64}(x -> -x, SMatrix{2, 2, Float64}(I), 1e-10)
+        @test CT_._diffusion_at(Lf, SVector(0.0, 0.0)) ≈ SMatrix{2, 2, Float64}(I)
+    end
+
+    @testset "default_regularization" begin
+        g80 = CartesianGrid((-1.0, 1.0, 80), (-1.0, 1.0, 80))
+        @test CT_.default_regularization(g80) ≈ 0.04
+        g160 = CartesianGrid((-1.0, 1.0, 160), (-1.0, 1.0, 160))
+        @test CT_.default_regularization(g160) < CT_.default_regularization(g80)
+    end
+
+    @testset "geometric_lagrangian router (regularized rank-1)" begin
+        sysf = CoupledSDEs((x, p, t) -> SVector(-x[1], -x[2]), [0.0, 0.0]; noise_strength = 1.0)
+        @test CT_._geometric_lagrangian(sysf, Float64) isa CT_._GeometricLagrangian
+
+        drift(u, p, t) = SVector(u[2], -u[1] - u[2])
+        gmat(u, p, t) = @SMatrix [0.0 0.0; 0.0 sqrt(2.0)]
+        sysd = CoupledSDEs(drift, SA[0.0, 0.0]; g = gmat, noise_prototype = SMatrix{2, 2}(zeros(2, 2)))
+        # rank-1 regularized -> ordinary GeometricLagrangian with an invertible (PD) metric
+        L = CT_._geometric_lagrangian(sysd, Float64; regularization = 0.04)
+        @test L isa CT_._GeometricLagrangian
+        @test isposdef(inv(L.Q_inv))
+        # rank-1 with no regularization is rejected
+        @test_throws ArgumentError CT_._geometric_lagrangian(sysd, Float64)
+
+        drift3(u, p, t) = SVector(u[2], u[3], -u[1])
+        g3(u, p, t) = @SMatrix [0.0 0.0 0.0; 0.0 0.0 0.0; 0.0 0.0 1.0]
+        sys3 = CoupledSDEs(drift3, SA[0.0, 0.0, 0.0]; g = g3, noise_prototype = SMatrix{3, 3}(zeros(3, 3)))
+        @test_throws ArgumentError CT_._geometric_lagrangian(sys3, Float64; regularization = 0.04)
+    end
+
+    @testset "regularized OLIM: equilibrium Langevin" begin
+        Vp(x) = x^3 - x
+        Vpot(x) = x^4 / 4 - x^2 / 2
+        Ustar(x, p) = p^2 / 2 + Vpot(x) - Vpot(-1.0)
+        drift(u, p, t) = SVector(u[2], -Vp(u[1]) - u[2])         # gamma = 1, closed form U*
+        gmat(u, p, t) = @SMatrix [0.0 0.0; 0.0 sqrt(2.0)]
+        sys = CoupledSDEs(drift, SA[-1.0, 0.0]; g = gmat, noise_prototype = SMatrix{2, 2}(zeros(2, 2)))
+
+        grid = CartesianGrid((-1.8, 0.6, 61), (-1.2, 1.2, 61))
+        qp = quasipotential(sys, grid, [-1.0, 0.0]; show_progress = false)
+        xs = grid.centers[1]; ps = grid.centers[2]; src = qp.source
+        K = CT_.default_K(grid)
+        # escape sheet (p > 0): the regularization bias is negligible there
+        se = Float64[]
+        for i in 1:61, j in 1:61
+            (-1.0 <= xs[i] <= 0.3 && 0.0 < ps[j] <= 1.0) || continue
+            (abs(i - src[1]) <= K && abs(j - src[2]) <= K) && continue
+            isfinite(qp.U[i, j]) || continue
+            push!(se, (qp.U[i, j] - Ustar(xs[i], ps[j]))^2)
+        end
+        @test sqrt(sum(se) / length(se)) <= 0.05                 # escape-sheet RMS
+        isad = argmin(abs.(xs)); jsad = argmin(abs.(ps))
+        @test abs(qp.U[isad, jsad] - 0.25) <= 0.02               # saddle barrier
+        @test qp.U[qp.source] == 0.0
+        @test all(>=(-1e-8), filter(isfinite, qp.U))
+    end
+
+    @testset "regularized OLIM: van der Pol (non-equilibrium)" begin
+        Vp(x) = x^3 - x
+        Dfric(x) = 1.0 - 0.3 * (1 - x^2)                         # state-dependent friction
+        drift(u, p, t) = SVector(u[2], -Dfric(u[1]) * u[2] - Vp(u[1]))
+        gmat(u, p, t) = @SMatrix [0.0 0.0; 0.0 sqrt(2.0)]
+        sys = CoupledSDEs(drift, SA[-1.0, 0.0]; g = gmat, noise_prototype = SMatrix{2, 2}(zeros(2, 2)))
+        grid = CartesianGrid((-1.8, 0.6, 41), (-1.2, 1.2, 41))
+        qp = quasipotential(sys, grid, [-1.0, 0.0]; show_progress = false)
+        xs = grid.centers[1]; ps = grid.centers[2]
+        @test all(isfinite, qp.U)                                # full field, no dead band
+        @test qp.U[qp.source] == 0.0
+        isad = argmin(abs.(xs)); jsad = argmin(abs.(ps))
+        @test 0.15 < qp.U[isad, jsad] < 0.24                     # finite, below equilibrium 0.25
+        col = [qp.U[isad, argmin(abs.(ps .- pp))] for pp in (0.0, 0.3, 0.6, 0.9)]
+        @test issorted(col)                                      # monotone escape sheet
+    end
 end


### PR DESCRIPTION
- Extends OLIM quasipotential to rank-1 (single noiseless coordinate) diffusions via a coordinate-aligned regularization: adds `δ · eₙeₙᵀ` to the trace-normalized metric, so the noisy block is exact and the regularizer vanishes under grid refinement.
- Adds `_degenerate_split` to classify diffusion matrices at construction time: full-rank passes through unchanged, exactly-one-zero-rowcol triggers regularized OLIM, two-or-more or non-coordinate-aligned null space throws a clear error.
- Caches drift data at cell centers (`_NodeData`) for additive noise so Simpson endpoint evaluations on already-visited centers skip the drift eval, matvec and sqrt.
